### PR TITLE
Implementing remaing Unit endpoints

### DIFF
--- a/src/API/Data/BuildingRelationshipsRepository.cs
+++ b/src/API/Data/BuildingRelationshipsRepository.cs
@@ -16,6 +16,8 @@ namespace API.Data
 			=> ExecuteDbPipeline("search all building support relationships", async db =>
 			{
 				var result = await db.BuildingRelationships
+					.Include(br => br.Unit)
+					.Include(br => br.Building)
 					.AsNoTracking()
 					.ToListAsync();
 				return Pipeline.Success(result);

--- a/src/API/Data/UnitsRepository.cs
+++ b/src/API/Data/UnitsRepository.cs
@@ -128,6 +128,7 @@ namespace API.Data
                     .Include(u => u.UnitMembers).ThenInclude(um => um.Person)
                     .Include(u => u.UnitMembers).ThenInclude(um => um.MemberTools)
                     .Include(u => u.SupportRelationships).ThenInclude(sr => sr.Department)
+                    .Include(u => u.BuildingRelationships).ThenInclude(sr => sr.Building)
                     .Single(u => u.Id == unit.Id);
 
                 //Write the logs with the whole enchilada 
@@ -138,6 +139,8 @@ namespace API.Data
                 db.UnitMembers.RemoveRange(unitAndRelated.UnitMembers);
                 //Remove SupportRelationships for unit
                 db.SupportRelationships.RemoveRange(unitAndRelated.SupportRelationships);
+                //Remove BuildingRelationships for unit
+                db.BuildingRelationships.RemoveRange(unitAndRelated.BuildingRelationships);
 
                 // Remove unit from the database.
                 db.Units.Remove(unit);

--- a/src/API/Data/UnitsRepository.cs
+++ b/src/API/Data/UnitsRepository.cs
@@ -148,7 +148,7 @@ namespace API.Data
         }
 
         internal static Task<Result<List<Unit>, Error>> GetChildren(HttpRequest req, int unitId) =>
-            ExecuteDbPipeline($"delete unit {unitId}", db =>
+            ExecuteDbPipeline($"get unit {unitId} children", db =>
                 TryFindUnit(db, unitId)
                 .Bind(u => TryGetChildren(db, u.Id)));
 

--- a/src/API/Data/UnitsRepository.cs
+++ b/src/API/Data/UnitsRepository.cs
@@ -196,5 +196,22 @@ namespace API.Data
             
             return Pipeline.Success(relationships);
         }
+
+        internal static Task<Result<List<SupportRelationship>, Error>> GetSupportedDepartments(HttpRequest req, int unitId) =>
+            ExecuteDbPipeline($"get unit {unitId} supported departments", db =>
+                TryFindUnit(db, unitId)
+                .Bind(u => TryGetSupportedDepartments(db, u.Id)));
+
+        private static async Task<Result<List<SupportRelationship>, Error>> TryGetSupportedDepartments(PeopleContext db, int unitId)
+        {
+            var relationships = await db.SupportRelationships
+                .Include(br => br.Unit)
+                .Include(br => br.Department)
+                .Where(br => br.UnitId == unitId)
+                .AsNoTracking()
+                .ToListAsync();
+            
+            return Pipeline.Success(relationships);
+        }
     }
 }

--- a/src/API/Data/UnitsRepository.cs
+++ b/src/API/Data/UnitsRepository.cs
@@ -179,5 +179,22 @@ namespace API.Data
             
             return Pipeline.Success(members);
         }
+
+        internal static Task<Result<List<BuildingRelationship>, Error>> GetSupportedBuildings(HttpRequest req, int unitId) =>
+            ExecuteDbPipeline($"get unit {unitId} supported buildings", db =>
+                TryFindUnit(db, unitId)
+                .Bind(u => TryGetSupportedBuildings(db, u.Id)));
+
+        private static async Task<Result<List<BuildingRelationship>, Error>> TryGetSupportedBuildings(PeopleContext db, int unitId)
+        {
+            var relationships = await db.BuildingRelationships
+                .Include(br => br.Unit)
+                .Include(br => br.Building)
+                .Where(br => br.UnitId == unitId)
+                .AsNoTracking()
+                .ToListAsync();
+            
+            return Pipeline.Success(relationships);
+        }
     }
 }

--- a/src/API/Data/UnitsRepository.cs
+++ b/src/API/Data/UnitsRepository.cs
@@ -213,5 +213,19 @@ namespace API.Data
             
             return Pipeline.Success(relationships);
         }
+
+        internal static Task<Result<List<Tool>, Error>> GetTools(HttpRequest req, int unitId) =>
+            ExecuteDbPipeline($"get unit {unitId} supported departments", db =>
+                TryFindUnit(db, unitId)
+                .Bind(u => TryGetTools(db, u.Id)));
+
+        private static async Task<Result<List<Tool>, Error>> TryGetTools(PeopleContext db, int unitId)
+        {
+            var tools = await db.Tools
+                .AsNoTracking()
+                .ToListAsync();
+            
+            return Pipeline.Success(tools);
+        }
     }
 }

--- a/src/API/Data/UnitsRepository.cs
+++ b/src/API/Data/UnitsRepository.cs
@@ -161,5 +161,23 @@ namespace API.Data
                 .ToListAsync();
             return Pipeline.Success(children);
         }
+
+        internal static Task<Result<List<UnitMember>, Error>> GetMembers(HttpRequest req, int unitId) =>
+            ExecuteDbPipeline($"get unit {unitId} members", db =>
+                TryFindUnit(db, unitId)
+                .Bind(u => TryGetMembers(db, u.Id)));
+
+        private static async Task<Result<List<UnitMember>, Error>> TryGetMembers(PeopleContext db, int unitId)
+        {
+            var members = await db.UnitMembers
+                .Include(u => u.Person)
+                .Include(u => u.Unit)
+                .Include(u => u.MemberTools)
+                .Where(u => u.UnitId == unitId)
+                .AsNoTracking()
+                .ToListAsync();
+            
+            return Pipeline.Success(members);
+        }
     }
 }

--- a/src/API/Functions/Buildings.cs
+++ b/src/API/Functions/Buildings.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using Models;
 using Microsoft.OpenApi.Models;
 using System.Net.Mime;
+using System.Linq;
 
 namespace API.Functions
 {
@@ -51,6 +52,7 @@ namespace API.Functions
             => Security.Authenticate(req)
                 .Bind(_ => BuildingsRepository.GetOne(buildingId)) //make sure the building exists before trying to get its supporting units
                 .Bind(_ => BuildingsRepository.GetSupportingUnits(buildingId))
+                .Bind(br => Pipeline.Success(br.Select(brx => new BuildingRelationshipResponse(brx)).ToList()))
                 .Finally(result => Response.Ok(req, result));
     }
 }

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -143,5 +143,17 @@ namespace API.Functions
                 .Bind(_ => UnitsRepository.GetSupportedDepartments(req, unitId))
                 .Bind(sr => Pipeline.Success(sr.Select(srx => new SupportRelationshipResponse(srx))))
                 .Finally(result => Response.Ok(req, result));
+
+        [FunctionName(nameof(Units.GetUnitTools))]
+        [OpenApiOperation(nameof(Units.GetUnitTools), nameof(Units), Summary = "List all unit tools", Description = "List all tools that are available to this unit.")]
+        [OpenApiParameter("unitId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SupportRelationshipResponse>))]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
+        public static Task<IActionResult> GetUnitTools(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/tools")] HttpRequest req, int unitId) 
+            => Security.Authenticate(req)
+                .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
+                .Bind(_ => UnitsRepository.GetTools(req, unitId))
+                .Finally(result => Response.Ok(req, result));    
     }
 }

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -129,6 +129,7 @@ namespace API.Functions
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
                 .Bind(_ => UnitsRepository.GetSupportedBuildings(req, unitId))
+                .Bind(sr => Pipeline.Success(sr.Select(srx => new BuildingRelationshipResponse(srx)).ToList()))
                 .Finally(result => Response.Ok(req, result));
 
         [FunctionName(nameof(Units.GetUnitSupportedDepartments))]
@@ -141,7 +142,7 @@ namespace API.Functions
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
                 .Bind(_ => UnitsRepository.GetSupportedDepartments(req, unitId))
-                .Bind(sr => Pipeline.Success(sr.Select(srx => new SupportRelationshipResponse(srx))))
+                .Bind(sr => Pipeline.Success(sr.Select(srx => new SupportRelationshipResponse(srx)).ToList()))
                 .Finally(result => Response.Ok(req, result));
 
         [FunctionName(nameof(Units.GetUnitTools))]

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -148,7 +148,7 @@ namespace API.Functions
         [FunctionName(nameof(Units.GetUnitTools))]
         [OpenApiOperation(nameof(Units.GetUnitTools), nameof(Units), Summary = "List all unit tools", Description = "List all tools that are available to this unit.")]
         [OpenApiParameter("unitId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit record.")]
-        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SupportRelationshipResponse>))]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<Tool>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> GetUnitTools(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/tools")] HttpRequest req, int unitId) 

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -118,5 +118,17 @@ namespace API.Functions
                 .Bind(_ => UnitsRepository.GetMembers(req, unitId))
 				.Bind(ms => Pipeline.Success(ms.Select(e => e.ToUnitMemberResponse(req.GetEntityPermissions()))))
                 .Finally(result => Response.Ok(req, result));
+
+        [FunctionName(nameof(Units.GetUnitSupportedBuildings))]
+        [OpenApiOperation(nameof(Units.GetUnitSupportedBuildings), nameof(Units), Summary = "List all supported buildings", Description = "List all buildings that receive IT support from this unit.")]
+        [OpenApiParameter("unitId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<BuildingRelationshipResponse>))]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
+        public static Task<IActionResult> GetUnitSupportedBuildings(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/supportedBuildings")] HttpRequest req, int unitId) 
+            => Security.Authenticate(req)
+                .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
+                .Bind(_ => UnitsRepository.GetSupportedBuildings(req, unitId))
+                .Finally(result => Response.Ok(req, result));
     }
 }

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -130,5 +130,18 @@ namespace API.Functions
                 .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
                 .Bind(_ => UnitsRepository.GetSupportedBuildings(req, unitId))
                 .Finally(result => Response.Ok(req, result));
+
+        [FunctionName(nameof(Units.GetUnitSupportedDepartments))]
+        [OpenApiOperation(nameof(Units.GetUnitSupportedDepartments), nameof(Units), Summary = "List all supported departments", Description = "List all departments that receive IT support from this unit.")]
+        [OpenApiParameter("unitId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SupportRelationshipResponse>))]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
+        public static Task<IActionResult> GetUnitSupportedDepartments(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/supportedDepartments")] HttpRequest req, int unitId) 
+            => Security.Authenticate(req)
+                .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
+                .Bind(_ => UnitsRepository.GetSupportedDepartments(req, unitId))
+                .Bind(sr => Pipeline.Success(sr.Select(srx => new SupportRelationshipResponse(srx))))
+                .Finally(result => Response.Ok(req, result));
     }
 }

--- a/src/API/Middleware/Request.cs
+++ b/src/API/Middleware/Request.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
 using System.Linq;
+using Models.Enums;
 
 namespace API.Middleware
 {
@@ -41,5 +42,19 @@ namespace API.Middleware
             ? Pipeline.BadRequest(results.Select(r => r.ErrorMessage))
             : Pipeline.Success(body);
         }
+    }
+
+    public static class HttpRequestExtensions
+    {
+        public static void SetEntityPermissions(this HttpRequest req, EntityPermissions permissions)
+        {
+            req.HttpContext.Items[Response.Headers.XUserPermissions] = permissions;
+            req.HttpContext.Response.Headers[Response.Headers.XUserPermissions] = permissions.ToString();
+            // TODO: CORS stuff...
+            req.HttpContext.Response.Headers[Response.Headers.AccessControlExposeHeaders] = Response.Headers.XUserPermissions;
+        }
+
+        public static EntityPermissions GetEntityPermissions(this HttpRequest req) 
+            => (EntityPermissions)req.HttpContext.Items[Response.Headers.XUserPermissions];
     }
 }

--- a/src/Models/DTO/BuildingRelationshipResponse.cs
+++ b/src/Models/DTO/BuildingRelationshipResponse.cs
@@ -3,6 +3,19 @@ namespace Models
     /// This relationship describes which IT Unit provides IT-related support for a given building.
     public class BuildingRelationshipResponse : Entity
     {
+        public BuildingRelationshipResponse()
+        {
+        }
+
+        public BuildingRelationshipResponse(BuildingRelationship br)
+        {
+            Id = br.Id;
+            UnitId = br.UnitId;
+            BuildingId = br.BuildingId;
+            Unit = new UnitResponse(br.Unit);
+            Building = br.Building;
+        }
+
         /// The ID of the unit in this relationship
         public int UnitId { get; set; }
         /// The ID of the department in this relationship
@@ -11,5 +24,6 @@ namespace Models
         public UnitResponse Unit { get; set; }
         /// The building in this relationship.
         public Building Building { get; set; }
+
     }
 }

--- a/src/Models/DTO/SupportRelationshipResponse.cs
+++ b/src/Models/DTO/SupportRelationshipResponse.cs
@@ -24,7 +24,9 @@ namespace Models
         public SupportRelationshipResponse(SupportRelationship sr)
         {
             Id = sr.Id;
+            DepartmentId = sr.DepartmentId;
             Department = sr.Department;
+            UnitId = sr.UnitId;
             Unit = new UnitResponse(sr.Unit);
         }
         

--- a/src/Models/Entities/Unit.cs
+++ b/src/Models/Entities/Unit.cs
@@ -10,6 +10,7 @@ namespace Models
 
         public List<UnitMember> UnitMembers { get; set; }
         public List<SupportRelationship> SupportRelationships { get; set; }
+        public List<BuildingRelationship> BuildingRelationships { get; set; }
 
 
         public Unit() {}

--- a/tests/API/Integration/BuildingRelationshipsTests.cs
+++ b/tests/API/Integration/BuildingRelationshipsTests.cs
@@ -21,7 +21,7 @@ namespace Integration
 			{
 				var resp = await GetAuthenticated("buildingRelationships");
 				AssertStatusCode(resp, HttpStatusCode.OK);
-				var actual = await resp.Content.ReadAsAsync<List<BuildingRelationship>>();
+				var actual = await resp.Content.ReadAsAsync<List<BuildingRelationshipResponse>>();
 				Assert.AreEqual(2, actual.Count);
 			}
 		}
@@ -40,7 +40,7 @@ namespace Integration
 			public async Task BuildingRelationshipsGetOneResponseHasCorrectShape()
 			{
 				var resp = await GetAuthenticated($"buildingRelationships/{TestEntities.BuildingRelationships.CityHallCityOfPawneeId}");
-				var actual = await resp.Content.ReadAsAsync<BuildingRelationship>();
+				var actual = await resp.Content.ReadAsAsync<BuildingRelationshipResponse>();
 				var expected = TestEntities.BuildingRelationships.CityHallCityOfPawnee;
 				Assert.AreEqual(expected.Id, actual.Id);
 				Assert.AreEqual(expected.Building.Id, actual.Building.Id);
@@ -62,7 +62,7 @@ namespace Integration
 			{
 				var resp = await PostAuthenticated("buildingRelationships", CityHallParksAndRec, ValidAdminJwt);
 				AssertStatusCode(resp, HttpStatusCode.Created);
-				var actual = await resp.Content.ReadAsAsync<BuildingRelationship>();
+				var actual = await resp.Content.ReadAsAsync<BuildingRelationshipResponse>();
 
 				Assert.NotZero(actual.Id);
 				Assert.AreEqual(CityHallParksAndRec.UnitId, actual.Unit.Id);
@@ -142,7 +142,7 @@ namespace Integration
 
 				var resp = await PutAuthenticated($"buildingRelationships/{TestEntities.BuildingRelationships.CityHallCityOfPawneeId}", req, ValidAdminJwt);
 				AssertStatusCode(resp, HttpStatusCode.OK);
-				var actual = await resp.Content.ReadAsAsync<BuildingRelationship>();
+				var actual = await resp.Content.ReadAsAsync<BuildingRelationshipResponse>();
 
 				Assert.AreEqual(TestEntities.BuildingRelationships.CityHallCityOfPawneeId, actual.Id);
 				Assert.AreEqual(req.BuildingId, actual.Building.Id);

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -300,7 +300,12 @@ namespace Integration
             [Test]
             public async Task DeleteUnitDoesNotCreateOrphans()
             {
-                var resp = await DeleteAuthenticated($"units/{TestEntities.Units.ParksAndRecUnitId}", ValidAdminJwt);
+                // Delete all the units to ensure all types of relations are exercised.
+                var resp = await DeleteAuthenticated($"units/{TestEntities.Units.AuditorId}", ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.NoContent);
+                resp = await DeleteAuthenticated($"units/{TestEntities.Units.ParksAndRecUnitId}", ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.NoContent);
+                resp = await DeleteAuthenticated($"units/{TestEntities.Units.CityOfPawneeUnitId}", ValidAdminJwt);
                 AssertStatusCode(resp, HttpStatusCode.NoContent);
                 
                 System.Environment.SetEnvironmentVariable("DatabaseConnectionString", Database.PeopleContext.LocalDatabaseConnectionString);
@@ -334,6 +339,13 @@ namespace Integration
 
                 Assert.IsEmpty(supportRelationships.Where(um => um.Unit == null));
                 Assert.IsEmpty(supportRelationships.Where(um => um.Department == null));
+
+                var buildingRelationships = db.BuildingRelationships
+                    .Include(sr => sr.Unit)
+                    .Include(sr => sr.Building);
+
+                Assert.IsEmpty(buildingRelationships.Where(um => um.Unit == null));
+                Assert.IsEmpty(buildingRelationships.Where(um => um.Building == null));
             }
         }
 

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -442,5 +442,39 @@ namespace Integration
                 Assert.True(actual.All(a => a.Building != null));
             }
         }
+
+
+        [TestFixture]
+        public class UnitGetSupportedDepartments : ApiTest
+        {
+            [Test]
+            public async Task AuthRequired()
+            {
+                var resp = await GetAuthenticated($"units/{TestEntities.Units.CityOfPawneeUnitId}/supportedDepartments", "bad token");
+                AssertStatusCode(resp, HttpStatusCode.Unauthorized);
+            }
+
+            [Test]
+            public async Task UnitMustExist()
+            {
+                var resp = await GetAuthenticated($"units/9999/supportedDepartments");
+                AssertStatusCode(resp, HttpStatusCode.NotFound);
+            }
+
+            [TestCase(TestEntities.Units.ParksAndRecUnitId, new[]{TestEntities.SupportRelationships.ParksAndRecRelationshipId, TestEntities.SupportRelationships.ParksAndRecUnitFireId})]
+            [TestCase(TestEntities.Units.AuditorId, new int[0])]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new int[0])]
+            public async Task CanGetExpectedRelationships(int unitId, int[] expectedRelationIds)
+            {
+                var resp = await GetAuthenticated($"units/{unitId}/supportedDepartments");
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                var actual = await resp.Content.ReadAsAsync<List<SupportRelationshipResponse>>();
+                AssertIdsMatchContent(expectedRelationIds, actual);
+                Assert.True(actual.All(a => a.UnitId == unitId));
+                Assert.True(actual.All(a => a.Unit != null));
+                Assert.True(actual.All(a => a.Unit.Id == unitId));
+                Assert.True(actual.All(a => a.Department != null));
+            }
+        }
     }
 }

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -476,5 +476,34 @@ namespace Integration
                 Assert.True(actual.All(a => a.Department != null));
             }
         }
+
+        [TestFixture]
+        public class UnitGetTools : ApiTest
+        {
+            [Test]
+            public async Task AuthRequired()
+            {
+                var resp = await GetAuthenticated($"units/{TestEntities.Units.CityOfPawneeUnitId}/tools", "bad token");
+                AssertStatusCode(resp, HttpStatusCode.Unauthorized);
+            }
+
+            [Test]
+            public async Task UnitMustExist()
+            {
+                var resp = await GetAuthenticated($"units/9999/tools");
+                AssertStatusCode(resp, HttpStatusCode.NotFound);
+            }
+
+            [TestCase(TestEntities.Units.ParksAndRecUnitId, new[]{TestEntities.Tools.HammerId})]
+            [TestCase(TestEntities.Units.AuditorId, new[]{TestEntities.Tools.HammerId})]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[]{TestEntities.Tools.HammerId})]
+            public async Task CanGetExpectedTools(int unitId, int[] expectedToolIds)
+            {
+                var resp = await GetAuthenticated($"units/{unitId}/tools");
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                var actual = await resp.Content.ReadAsAsync<List<Tool>>();
+                AssertIdsMatchContent(expectedToolIds, actual);
+            }
+        }
     }
 }


### PR DESCRIPTION
Implement remaining Unit endpoints:
* "get unit children"
* "get unit members"
* "get buildings supported by unit"
* "get departments supported by unit"
* "get tools accessible by unit"

And from Jared's punchlist: 
* On "get unit members" ensure member notes are stripped as appropriate 
* On "delete unit" ensure no Unit relations are orphaned