### PR TITLE
Address OutOfMemory exception on durable tasks

### DIFF
--- a/src/Tasks/host.json
+++ b/src/Tasks/host.json
@@ -11,7 +11,9 @@
     "extensions": {
         "durableTask": {
             "maxConcurrentActivityFunctions": 3,
-            "maxConcurrentOrchestratorFunctions": 3
+            "maxConcurrentOrchestratorFunctions": 3,
+            "extendedSessionsEnabled": true,
+            "extendedSessionIdleTimeoutInSeconds": 30
         }
     }
 }


### PR DESCRIPTION
Durable function apps can throw out of memory exceptions if there's a lot of data being passed from an orchestrator to an activity. This is one recommended way to address that. See also this [GitHub issue](https://github.com/Azure/azure-functions-durable-extension/issues/340).