### PR TITLE
Issues/19

### DIFF
--- a/pact/StateServer/Functions.cs
+++ b/pact/StateServer/Functions.cs
@@ -146,6 +146,11 @@ namespace StateServer
                 ");
             peopleContext.Database.ExecuteSqlRaw(@"
                 SELECT
+                    setval(pg_get_serial_sequence('public.people', 'id'), 
+                    (SELECT MAX(id) FROM public.people));
+                ");
+            peopleContext.Database.ExecuteSqlRaw(@"
+                SELECT
                     setval(pg_get_serial_sequence('public.hr_people', 'id'), 
                     (SELECT MAX(id) FROM public.hr_people));
                 ");

--- a/src/API/Data/DepartmentsRepository.cs
+++ b/src/API/Data/DepartmentsRepository.cs
@@ -52,6 +52,7 @@ namespace API.Data
                 .Include(m => m.Unit.Parent)
                 .Where(m => m.Person.DepartmentId == departmentId)
                 .Select(m => m.Unit)
+                .Distinct()
                 .AsNoTracking().ToListAsync();
             return Pipeline.Success(result);
         }


### PR DESCRIPTION
Resolves #19 - duplicate Units for requests to `departments/{id}/memberUnits`.
Much like #14 it was simply missing a Distinct clause.
