### PR TITLE
Fix comparisons of system and JWT nbf/exp times

### DIFF
--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -176,8 +176,15 @@ namespace API.Middleware
                 return Pipeline.Unauthorized("Access token has expired.");
 
             // check for unripe token
+            var utcNow = DateTime.UtcNow;
+            var nowEpoch = (utcNow - Epoch).TotalSeconds;
+            var nbf = Epoch.AddSeconds((float)jwt.nbf);     
             if(DateTime.UtcNow < Epoch.AddSeconds((float)jwt.nbf))
-                return Pipeline.Unauthorized("Access token is not yet valid.");
+                return Pipeline.Unauthorized($@"Access token is not yet valid. 
+                now: {utcNow.ToString("d MMMM hh:mm:ss.FFF")}  
+                nbf time: {nbf.ToString("d MMMM hh:mm:ss.FFF")} 
+                now value: {nowEpoch}
+                nbf value: {jwt.nbf}");
 
             return Pipeline.Success(jwt.user_name);
         }

--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -175,15 +175,11 @@ namespace API.Middleware
 
             // check for expired token
             if(nowUnix > (double)jwt.exp)
-                return Pipeline.Unauthorized($@"Access token has expired.
-                now: {nowUnix}
-                exp: {jwt.exp}");
+                return Pipeline.Unauthorized("Access token has expired.");
 
             // check for unripe token
             if(nowUnix < (double)jwt.nbf)
-                return Pipeline.Unauthorized($@"Access token is not yet valid. 
-                now: {nowUnix}  
-                nbf: {jwt.nbf}");
+                return Pipeline.Unauthorized("Access token is not yet valid.");
 
             return Pipeline.Success(jwt.user_name);
         }

--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -171,20 +171,19 @@ namespace API.Middleware
 
         private static Result<string,Error> ValidateJWT(UaaJwt jwt)
         {
+            var nowUnix = System.Math.Floor((DateTime.UtcNow - Epoch).TotalSeconds);
+
             // check for expired token
-            if(DateTime.UtcNow > Epoch.AddSeconds((float)(jwt.exp)))
-                return Pipeline.Unauthorized("Access token has expired.");
+            if(nowUnix > (double)jwt.exp)
+                return Pipeline.Unauthorized($@"Access token has expired.
+                now: {nowUnix}
+                exp: {jwt.exp}");
 
             // check for unripe token
-            var utcNow = DateTime.UtcNow;
-            var nowEpoch = (utcNow - Epoch).TotalSeconds;
-            var nbf = Epoch.AddSeconds((float)jwt.nbf);     
-            if(DateTime.UtcNow < Epoch.AddSeconds((float)jwt.nbf))
+            if(nowUnix < (double)jwt.nbf)
                 return Pipeline.Unauthorized($@"Access token is not yet valid. 
-                now: {utcNow.ToString("d MMMM hh:mm:ss.FFF")}  
-                nbf time: {nbf.ToString("d MMMM hh:mm:ss.FFF")} 
-                now value: {nowEpoch}
-                nbf value: {jwt.nbf}");
+                now: {nowUnix}  
+                nbf: {jwt.nbf}");
 
             return Pipeline.Success(jwt.user_name);
         }


### PR DESCRIPTION
When determining whether a JWT was expired (`exp`) or not net valid (`nbf`) we would convert the current UNIX time to a DateTime. This conversion sometimes erroneously resulted in a DateTime that was set a few minutes in the future. The JWT validation check would fail because the JWT appeared as not yet valid.

This PR simplifies the method of comparing the JWT `nbf` and `exp` and fixes the bug.

Fixes #20