### PR TITLE
Feature/issues 23

### DIFF
--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -102,6 +102,9 @@ namespace API.Data
         public static Task<Result<Person, Error>> GetOne(int id) 
             => ExecuteDbPipeline("get a person by ID", db => 
                 TryFindPerson(db, id));
+        public static Task<Result<Person, Error>> GetOne(string id) 
+            => ExecuteDbPipeline("get a person by Netid", db => 
+                TryFindPerson(db, id));
 
         public static Task<Result<List<UnitMember>, Error>> GetMemberships(int id) 
             => ExecuteDbPipeline("fetch unit memberships", db =>

--- a/src/API/Functions/People.cs
+++ b/src/API/Functions/People.cs
@@ -42,11 +42,18 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(Person))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No person was found with the provided ID.")]
         public static Task<IActionResult> PeopleGetOne(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}")] HttpRequest req, int id) 
-            => Security.Authenticate(req)
-                .Bind(requestor => AuthorizationRepository.DeterminePersonPermissions(req, requestor, id))
-                .Bind(_ => PeopleRepository.GetOne(id))
-                .Finally(result => Response.Ok(req, result));
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}")] HttpRequest req, string id) 
+            =>  Security.Authenticate(req)
+                .Bind(requestor => 
+                    int.TryParse(id, out int value)
+                    ? AuthorizationRepository.DeterminePersonPermissions(req, requestor, value)
+                    : AuthorizationRepository.DeterminePersonPermissions(req, requestor, id))
+                .Bind(_ => 
+                    int.TryParse(id, out int value)
+                    ? PeopleRepository.GetOne(value)
+                    : PeopleRepository.GetOne(id))
+                .Finally(result => Response.Ok(req, result));                    
+            
 
         [FunctionName(nameof(People.PeopleGetMemberships))]
         [OpenApiOperation(nameof(People.PeopleGetMemberships), nameof(People), Summary = "List unit memberships", Description = "List all units for which this person does IT work.")]

--- a/src/API/Functions/People.cs
+++ b/src/API/Functions/People.cs
@@ -62,24 +62,13 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No person was found with the provided ID.")]
         public static Task<IActionResult> PeopleGetMemberships(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}/memberships")] HttpRequest req, string id) 
-            {
-               if(int.TryParse(id, out int value))
-               {
-                   return  Security.Authenticate(req)
-                    .Bind(_ => PeopleRepository.GetMemberships(value))
-                    .Finally(result => Response.Ok(req, result));
-               }
-               else
-               {
-                   return  Security.Authenticate(req)
-                    .Bind(_ => PeopleRepository.GetMemberships(id))
-                    .Finally(result => Response.Ok(req, result));
-
-               }                
+            => Security.Authenticate(req)
+                .Bind(_ => 
+                    int.TryParse(id, out int value)
+                    ? PeopleRepository.GetMemberships(value)
+                    : PeopleRepository.GetMemberships(id))
+                .Finally(result => Response.Ok(req, result));
                 
-            }
-
-
         [FunctionName(nameof(People.PeopleUpdate))]
         [OpenApiOperation(nameof(People.PeopleUpdate), nameof(People), Summary = "Update person information", Description = "Update a person's location, expertise, and responsibilities/job classes.\n\n_Authorization_: The JWT must represent either the person whose record is being modified (i.e., a person can modify their own record), or someone who has permissions to manage a unit of which this person is a member (i.e., typically that person's manager/supervisor.)")]
         [OpenApiParameter("id", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the person record.")]

--- a/tests/API/Integration/PeopleTests.cs
+++ b/tests/API/Integration/PeopleTests.cs
@@ -215,6 +215,15 @@ namespace Integration
                 var resp = await GetAuthenticated($"people/{personId}", jwt);
                 AssertPermissions(resp, expectedPermissions);
             }
+
+            [Test]
+            public async Task CanGetUserByNetid()
+            {
+                var resp = await GetAuthenticated($"people/{TestEntities.People.RSwanson.Netid}");
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                var actual = await resp.Content.ReadAsAsync<Person>();
+                Assert.AreEqual(TestEntities.People.RSwanson.Id, actual.Id);
+            }
         }
 
         public class GetMemberships : ApiTest


### PR DESCRIPTION
Resolves #23 
Adds a overloads for fetching, and checking the permissions for, a single user by their `Netid`.
Refactors of functions that need to take an `int` or `string` value.
Test to cover fetching a single user by `Netid`.