### PR TITLE
Reduce API/Tasks memory consumption

### DIFF
--- a/src/API/Data/DataRepository.cs
+++ b/src/API/Data/DataRepository.cs
@@ -28,7 +28,7 @@ namespace API.Data
 
         protected static void LogPrevious<T>(HttpRequest req, T value) where T : Entity
         {
-            req.HttpContext.Items[LogProps.RecordBody] = JsonConvert.SerializeObject(value, Models.Json.JsonSerializerSettings);
+            req.HttpContext.Items[LogProps.RecordBody] = JsonConvert.SerializeObject(value, Json.JsonSerializerSettings);
         }
     }
 }

--- a/src/API/Functions/Authorization.cs
+++ b/src/API/Functions/Authorization.cs
@@ -21,7 +21,7 @@ namespace API.Functions
 
 		[FunctionName(nameof(Authorization.Options))]
 		[OpenApiIgnore]
-		public static IActionResult Options(
+		public static Task<IActionResult> Options(
 			[HttpTrigger(AuthorizationLevel.Anonymous, "options", Route = "{*url}")] HttpRequest req)
 			=> Response.Ok(req, Pipeline.Success(string.Empty));
 

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -3,13 +3,14 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using API.Middleware;
+using System.Threading.Tasks;
 
 namespace API.Functions
 {
     public static class HealthCheck
     {
         [FunctionName(nameof(HealthCheck.Ping))]
-        public static IActionResult Ping(
+        public static Task<IActionResult> Ping(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req) 
                 => Response.Ok(req, Pipeline.Success("Pong!"));
     }

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -11,6 +11,6 @@ namespace API.Functions
         [FunctionName(nameof(HealthCheck.Ping))]
         public static IActionResult Ping(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req) 
-                => Response.Ok(req, Pipeline.Success("Pong!"));
+                => new OkObjectResult("Pong!"); // Response.Ok(req, Pipeline.Success("Pong!"));
     }
 }

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -11,6 +11,6 @@ namespace API.Functions
         [FunctionName(nameof(HealthCheck.Ping))]
         public static IActionResult Ping(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req) 
-                => new OkObjectResult("Pong!"); // Response.Ok(req, Pipeline.Success("Pong!"));
+                => Response.Ok(req, Pipeline.Success("Pong!"));
     }
 }

--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -78,13 +78,13 @@ namespace API.Middleware
             return logger;
         }
 
-        private static ILogger Logger = 
+        private static Lazy<ILogger> Logger = new Lazy<ILogger>(() => 
             new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .TryAddAzureAppInsightsSink()
                 .TryAddPostgresqlDatabaseSink()
-                .CreateLogger();
+                .CreateLogger());
 
         public static ILogger GetLogger(HttpRequest req)
         {
@@ -97,7 +97,7 @@ namespace API.Middleware
                 ? (DateTime.UtcNow - (DateTime)req.HttpContext.Items[LogProps.ElapsedTime]).TotalMilliseconds
                 : -1;
 
-            return Logger
+            return Logger.Value
                 .ForContext(LogProps.ElapsedTime, elapsed)
                 .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
                 .ForContext(LogProps.RequestMethod, req.Method)

--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -78,6 +78,14 @@ namespace API.Middleware
             return logger;
         }
 
+        private static ILogger Logger = 
+            new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .TryAddAzureAppInsightsSink()
+                .TryAddPostgresqlDatabaseSink()
+                .CreateLogger();
+
         public static ILogger GetLogger(HttpRequest req)
         {
             var pathParts = req.Path.HasValue
@@ -89,13 +97,7 @@ namespace API.Middleware
                 ? (DateTime.UtcNow - (DateTime)req.HttpContext.Items[LogProps.ElapsedTime]).TotalMilliseconds
                 : -1;
 
-            return 
-                new LoggerConfiguration()
-                .Enrich.FromLogContext()
-                .WriteTo.Console()
-                .TryAddAzureAppInsightsSink()
-                .TryAddPostgresqlDatabaseSink()
-                .CreateLogger()
+            return Logger
                 .ForContext(LogProps.ElapsedTime, elapsed)
                 .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
                 .ForContext(LogProps.RequestMethod, req.Method)

--- a/src/API/Middleware/Pipeline.cs
+++ b/src/API/Middleware/Pipeline.cs
@@ -65,7 +65,7 @@ namespace API.Middleware
                     Errors = Messages?.ToList(),
                     Details = Exception == null ? "(none)" : includeStackTrace ? Exception.ToString() : Exception.Message
                 };
-            var json = JsonConvert.SerializeObject(content);
+            var json = JsonConvert.SerializeObject(content, Json.JsonSerializerSettings);
             return Response.ContentResponse(req, StatusCode, "application/json", json);
         }
     }

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -32,8 +32,10 @@ namespace API.Middleware
         {
             if (result.IsSuccess)
             {
-                if (statusCode != HttpStatusCode.OK)
+                if (req.Method.ToLower() != "get")
+                {
                     await Logging.GetLogger(req).SuccessResult(req, statusCode);
+                }
                 return resultGenerator(result.Value);
             }
             else 

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -139,14 +139,14 @@ namespace API.Middleware
         private static void SuccessResult(this Serilog.ILogger logger, HttpRequest request, HttpStatusCode statusCode) 
             => logger
                 .ForContext(LogProps.StatusCode, (int)statusCode)
-                .ForContext(LogProps.RequestBody, request.ContentLength > 0 ? request.ReadAsStringAsync().Result : null)
+                // .ForContext(LogProps.RequestBody, request.ContentLength > 0 ? request.ReadAsStringAsync().Result : null)
                 .ForContext(LogProps.RecordBody, request.HttpContext.Items[LogProps.RecordBody])
                 .Information($"[{{{LogProps.StatusCode}}}] {{{LogProps.RequestorNetid}}} - {{{LogProps.RequestMethod}}} {{{LogProps.Function}}}{{{LogProps.RequestParameters}}}{{{LogProps.RequestQuery}}}");
 
         private static void FailureResult<T>(this Serilog.ILogger logger, HttpRequest request, Error error) 
             => logger
                 .ForContext(LogProps.StatusCode, (int)error.StatusCode)
-                .ForContext(LogProps.RequestBody, request.ContentLength > 0 ? request.ReadAsStringAsync().Result : null)
+                // .ForContext(LogProps.RequestBody, request.ContentLength > 0 ? request.ReadAsStringAsync().Result : null)
                 .ForContext(LogProps.RecordBody, request.HttpContext.Items[LogProps.RecordBody])
                 .ForContext(LogProps.ErrorMessages, JsonConvert.SerializeObject(error.Messages))
                 .Error(error.Exception, $"[{{{LogProps.StatusCode}}}] {{{LogProps.RequestorNetid}}} - {{{LogProps.RequestMethod}}} {{{LogProps.Function}}}{{{LogProps.RequestParameters}}}{{{LogProps.RequestQuery}}}:\nErrors: {{{LogProps.ErrorMessages}}}.");

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -30,16 +30,15 @@ namespace API.Middleware
             HttpStatusCode statusCode, 
             Func<T,IActionResult> resultGenerator)
         {
-            var logger = Logging.GetLogger(req);
             if (result.IsSuccess)
             {
                 if (statusCode != HttpStatusCode.OK)
-                    await logger.SuccessResult(req, statusCode);
+                    await Logging.GetLogger(req).SuccessResult(req, statusCode);
                 return resultGenerator(result.Value);
             }
             else 
             {
-                await logger.FailureResult<T>(req, result.Error);
+                await Logging.GetLogger(req).FailureResult<T>(req, result.Error);
                 return result.Error.ToResponse(req);
             }
         }

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Text;
 using System.Net.Http.Headers;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace API.Middleware
 {
@@ -23,7 +24,7 @@ namespace API.Middleware
             public const string AccessControlExposeHeaders = "Access-Control-Expose-Headers";
         }
         
-        private static IActionResult Generate<T>(
+        private static async Task<IActionResult> Generate<T>(
             HttpRequest req, 
             Result<T, Error> result, 
             HttpStatusCode statusCode, 
@@ -32,32 +33,32 @@ namespace API.Middleware
             var logger = Logging.GetLogger(req);
             if (result.IsSuccess)
             {
-                // if (statusCode != HttpStatusCode.OK)
-                    logger.SuccessResult(req, statusCode);
+                if (statusCode != HttpStatusCode.OK)
+                    await logger.SuccessResult(req, statusCode);
                 return resultGenerator(result.Value);
             }
             else 
             {
-                logger.FailureResult<T>(req, result.Error);
+                await logger.FailureResult<T>(req, result.Error);
                 return result.Error.ToResponse(req);
             }
         }
 
         /// <summary>Return an HTTP 200 response with content, or an appropriate HTTP error response.</summary>
-        public static IActionResult Ok<T>(HttpRequest req, Result<T, Error> result)
+        public static Task<IActionResult> Ok<T>(HttpRequest req, Result<T, Error> result)
             => Generate(req, result, HttpStatusCode.OK, val => JsonResponse(req, val, HttpStatusCode.OK));
 
         /// <summary>Return an HTTP 201 response with content, with the URL for the resource and the resource itself.</summary>
-        public static IActionResult Created<T>(HttpRequest req, Result<T, Error> result) where T : Models.Entity
+        public static Task<IActionResult> Created<T>(HttpRequest req, Result<T, Error> result) where T : Models.Entity
 		    => Generate(req, result, HttpStatusCode.Created, val => JsonResponse(req, val, HttpStatusCode.Created));
 
         /// <summary>Return an HTTP 204 indicating success, but nothing to return.</summary>
-        public static IActionResult NoContent<T>(HttpRequest req, Result<T, Error> result)
+        public static Task<IActionResult> NoContent<T>(HttpRequest req, Result<T, Error> result)
             => Generate(req, result, HttpStatusCode.NoContent, val => StatusCodeResponse(req, HttpStatusCode.NoContent));
 
 
         /// <summary>Return an HTTP 200 response with XML content, or an appropriate HTTP error response.</summary>
-        public static IActionResult OkXml<T>(HttpRequest req, Result<T, Error> result)
+        public static Task<IActionResult> OkXml<T>(HttpRequest req, Result<T, Error> result)
             => Generate(req, result, HttpStatusCode.OK, val => XmlResponse(req, val, HttpStatusCode.OK));
 
         private static IActionResult JsonResponse<T>(HttpRequest req, T value, HttpStatusCode status)
@@ -136,19 +137,25 @@ namespace API.Middleware
             }
         }
 
-        private static void SuccessResult(this Serilog.ILogger logger, HttpRequest request, HttpStatusCode statusCode) 
-            => logger
-                .ForContext(LogProps.StatusCode, (int)statusCode)
-                // .ForContext(LogProps.RequestBody, request.ContentLength > 0 ? request.ReadAsStringAsync().Result : null)
-                .ForContext(LogProps.RecordBody, request.HttpContext.Items[LogProps.RecordBody])
-                .Information($"[{{{LogProps.StatusCode}}}] {{{LogProps.RequestorNetid}}} - {{{LogProps.RequestMethod}}} {{{LogProps.Function}}}{{{LogProps.RequestParameters}}}{{{LogProps.RequestQuery}}}");
+        private static async Task SuccessResult(this Serilog.ILogger logger, HttpRequest request, HttpStatusCode statusCode) 
+            {
+                var requestBody = request.ContentLength > 0 ? await request.ReadAsStringAsync() : null;
+                logger
+                    .ForContext(LogProps.StatusCode, (int)statusCode)
+                    .ForContext(LogProps.RequestBody, requestBody)
+                    .ForContext(LogProps.RecordBody, request.HttpContext.Items[LogProps.RecordBody])
+                    .Information($"[{{{LogProps.StatusCode}}}] {{{LogProps.RequestorNetid}}} - {{{LogProps.RequestMethod}}} {{{LogProps.Function}}}{{{LogProps.RequestParameters}}}{{{LogProps.RequestQuery}}}");
+            }
 
-        private static void FailureResult<T>(this Serilog.ILogger logger, HttpRequest request, Error error) 
-            => logger
+        private static async Task FailureResult<T>(this Serilog.ILogger logger, HttpRequest request, Error error) 
+        {
+            var requestBody = request.ContentLength > 0 ? await request.ReadAsStringAsync() : null;
+            logger
                 .ForContext(LogProps.StatusCode, (int)error.StatusCode)
-                // .ForContext(LogProps.RequestBody, request.ContentLength > 0 ? request.ReadAsStringAsync().Result : null)
+                .ForContext(LogProps.RequestBody, requestBody)
                 .ForContext(LogProps.RecordBody, request.HttpContext.Items[LogProps.RecordBody])
-                .ForContext(LogProps.ErrorMessages, JsonConvert.SerializeObject(error.Messages))
+                .ForContext(LogProps.ErrorMessages, JsonConvert.SerializeObject(error.Messages, Json.JsonSerializerSettings))
                 .Error(error.Exception, $"[{{{LogProps.StatusCode}}}] {{{LogProps.RequestorNetid}}} - {{{LogProps.RequestMethod}}} {{{LogProps.Function}}}{{{LogProps.RequestParameters}}}{{{LogProps.RequestQuery}}}:\nErrors: {{{LogProps.ErrorMessages}}}.");
+        }
     }
 }

--- a/src/Tasks/Logging.cs
+++ b/src/Tasks/Logging.cs
@@ -61,13 +61,15 @@ namespace Tasks
         public static ILogger GetLogger(IDurableOrchestrationContext ctx, object properties = null) 
             => GetLogger(ctx.InstanceId, ctx.Name, properties);
 
-        public static ILogger GetLogger(string instanceId, string function, object properties = null) 
-            => new LoggerConfiguration()
+        private static ILogger Logger = new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .WriteTo.Console(Serilog.Events.LogEventLevel.Information)
                 .TryAddAzureAppInsightsSink()
                 .TryAddPostgresqlDatabaseSink()
-                .CreateLogger()
+                .CreateLogger();
+
+        public static ILogger GetLogger(string instanceId, string function, object properties = null) 
+            => Logger
                 .ForContext(LogProps.InvocationId, System.Guid.Parse(instanceId))
                 .ForContext(LogProps.Function, function)
                 .ForContext(LogProps.Properties, properties == null ? null : JsonConvert.SerializeObject(properties, Formatting.Indented));        

--- a/src/Tasks/Logging.cs
+++ b/src/Tasks/Logging.cs
@@ -72,6 +72,6 @@ namespace Tasks
             => Logger
                 .ForContext(LogProps.InvocationId, System.Guid.Parse(instanceId))
                 .ForContext(LogProps.Function, function)
-                .ForContext(LogProps.Properties, properties == null ? null : JsonConvert.SerializeObject(properties, Formatting.Indented));        
+                .ForContext(LogProps.Properties, properties == null ? null : JsonConvert.SerializeObject(properties, Models.Json.JsonSerializerSettings));        
     }
 }

--- a/src/Tasks/People.cs
+++ b/src/Tasks/People.cs
@@ -34,12 +34,12 @@ namespace Tasks
                     nameof(FetchUAAToken), RetryOptions, null);
 
                 // Aggregate all the HR records of various different types
-                var hrRecords = await context.CallActivityWithRetryAsync<IEnumerable<ProfileEmployee>>(
-                    nameof(FetchPeopleFromProfileApi), RetryOptions, uaaJwt);
-
+                var hrRows = await context.CallActivityWithRetryAsync<IEnumerable<string>>(
+                    nameof(UpdatePeopleFromProfileApi), RetryOptions, uaaJwt);
                 // Refresh the HrPeople table with the Profile API data
                 await context.CallActivityWithRetryAsync(
-                        nameof(BulkInsertHrPeople), RetryOptions, hrRecords);
+                        nameof(BulkInsertHrPeople), RetryOptions, hrRows);
+                        
                 // Add/update Departments from new HR data
                 await context.CallActivityWithRetryAsync(
                         nameof(UpdateDepartmentRecords), RetryOptions, null);
@@ -74,8 +74,8 @@ namespace Tasks
 
 
         // Aggregate all HR records of a certain type from the IMS Profile API
-        [FunctionName(nameof(FetchPeopleFromProfileApi))]
-        public static async Task<IEnumerable<ProfileEmployee>> FetchPeopleFromProfileApi([ActivityTrigger] IDurableActivityContext context)
+        [FunctionName(nameof(UpdatePeopleFromProfileApi))]
+        public static async Task<IEnumerable<string>> UpdatePeopleFromProfileApi([ActivityTrigger] IDurableActivityContext context)
         {
             var jwt = context.GetInput<string>();
             var hrRecords = new List<ProfileEmployee>();
@@ -95,7 +95,14 @@ namespace Tasks
                 } while (hasMore);
             }
 
-            return Clean(hrRecords);
+            return Clean(hrRecords).Select(emp => MapToHrPeopleRow(emp));
+        }
+
+        private static string MapToHrPeopleRow(ProfileEmployee emp)
+        {
+            var p = new HrPerson();
+            emp.MapToHrPerson(p);
+            return $"{p.Name}\t{p.NameFirst}\t{p.NameLast}\t{p.Netid.ToLowerInvariant()}\t{p.Position}\t{p.Campus}\t{p.CampusPhone}\t{p.CampusEmail}\t{p.HrDepartment}\t{p.HrDepartmentDescription}";
         }
 
         private static async Task<ProfileResponse> FetchProfileApiPage(IDurableActivityContext context, string jwt, string type, int page)
@@ -130,7 +137,7 @@ namespace Tasks
         {
             try
             {
-                var emps = context.GetInput<IEnumerable<ProfileEmployee>>();
+                var rows = context.GetInput<IEnumerable<string>>();
                 var connStr = Utils.Env("DatabaseConnectionString", required: true);
                 using (var db = new Npgsql.NpgsqlConnection(connStr))
                 {
@@ -142,11 +149,9 @@ namespace Tasks
                     // Quickly import all HR records from the IMS Profile API
                     using (var writer = db.BeginTextImport("COPY hr_people (name, name_first, name_last, netid, position, campus, campus_phone, campus_email, hr_department, hr_department_desc) FROM STDIN"))
                     {
-                        foreach(var emp in emps)
-                        {
-                            var p = new HrPerson();
-                            emp.MapToHrPerson(p);
-                            await writer.WriteLineAsync($"{p.Name}\t{p.NameFirst}\t{p.NameLast}\t{p.Netid.ToLowerInvariant()}\t{p.Position}\t{p.Campus}\t{p.CampusPhone}\t{p.CampusEmail}\t{p.HrDepartment}\t{p.HrDepartmentDescription}");
+                        foreach (var row in rows)
+                        {                            
+                            await writer.WriteLineAsync(row);
                         }
                         await writer.FlushAsync();
                     }

--- a/src/Tasks/People.cs
+++ b/src/Tasks/People.cs
@@ -144,7 +144,7 @@ namespace Tasks
                     await db.OpenAsync();
                     // Clear all records in hr_people
                     var cmd = db.CreateCommand();
-                    cmd.CommandText = "TRUNCATE hr_people;";
+                    cmd.CommandText = "TRUNCATE hr_people; setval(pg_get_serial_sequence('public.hr_people', 'id'),1);";
                     await cmd.ExecuteNonQueryAsync();
                     // Quickly import all HR records from the IMS Profile API
                     using (var writer = db.BeginTextImport("COPY hr_people (name, name_first, name_last, netid, position, campus, campus_phone, campus_email, hr_department, hr_department_desc) FROM STDIN"))


### PR DESCRIPTION
* Create Serilog ILogger instances only as needed. 
* Don't log API GET requests; log everything else.
* Make all logging async. 
* Use consistent JSON serialization settings when logging object bodies.

Resolves #25