### PR TITLE
Minimize task resource footprint.

### DIFF
--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -15,36 +15,36 @@ variables:
     value: 'ubuntu-20.04'
 
 stages:
-# - stage: Test
-#   displayName: Test
+- stage: Test
+  displayName: Test
 
-#   jobs: 
-#     - job: ApiTest
-#       displayName: API Tests
-#       pool:
-#         vmImage: $(vmImageName)
+  jobs: 
+    - job: ApiTest
+      displayName: API
+      pool:
+        vmImage: $(vmImageName)
 
-#       steps:
-#         - task: DotNetCoreCLI@2
-#           displayName: Unit Tests
-#           inputs:
-#             command: test
-#             projects: tests/API/Unit/Unit.csproj
+      steps:
+        - task: DotNetCoreCLI@2
+          displayName: Unit
+          inputs:
+            command: test
+            projects: tests/API/Unit/Unit.csproj
             
-#         - task: DotNetCoreCLI@2
-#           displayName: Integration Tests
-#           inputs:
-#             command: test
-#             projects: tests/API/Integration/Integration.csproj  
+        - task: DotNetCoreCLI@2
+          displayName: Integration
+          inputs:
+            command: test
+            projects: tests/API/Integration/Integration.csproj  
 
 - stage: Package
   displayName: Package  
-  # dependsOn: Test
-  # condition: succeeded()
+  dependsOn: Test
+  condition: succeeded()
 
   jobs:
   - job: PackageApiApp
-    displayName: Package API Function App
+    displayName: API Function App
     pool:
       vmImage: $(vmImageName)
 
@@ -70,7 +70,7 @@ stages:
       artifact: ApiDeploymentPackage
 
   - job: PackageTasksApp
-    displayName: Package Tasks Function App
+    displayName: Tasks Function App
     pool:
       vmImage: $(vmImageName)
 
@@ -102,7 +102,7 @@ stages:
 
   jobs:
   - deployment: DeployAPI
-    displayName: Deploy API
+    displayName: API
     environment: 'development'
     pool:
       vmImage: $(vmImageName)
@@ -121,7 +121,7 @@ stages:
               package: '$(Pipeline.Workspace)/ApiDeploymentPackage/ApiFunctionApp.zip'
 
   - deployment: DeployTasks
-    displayName: Deploy Tasks
+    displayName: Tasks
     environment: 'development'
     pool:
       vmImage: $(vmImageName)

--- a/src/Database/Migrations/20210329154226_UpdateHrPeopleWithMarkedForDeleteFlag.Designer.cs
+++ b/src/Database/Migrations/20210329154226_UpdateHrPeopleWithMarkedForDeleteFlag.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Database.Migrations
 {
     [DbContext(typeof(PeopleContext))]
-    partial class PeopleContextModelSnapshot : ModelSnapshot
+    [Migration("20210329154226_UpdateHrPeopleWithMarkedForDeleteFlag")]
+    partial class UpdateHrPeopleWithMarkedForDeleteFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Database/Migrations/20210329154226_UpdateHrPeopleWithMarkedForDeleteFlag.cs
+++ b/src/Database/Migrations/20210329154226_UpdateHrPeopleWithMarkedForDeleteFlag.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Database.Migrations
+{
+    public partial class UpdateHrPeopleWithMarkedForDeleteFlag : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "marked_for_delete",
+                schema: "public",
+                table: "hr_people",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "marked_for_delete",
+                schema: "public",
+                table: "hr_people");
+        }
+    }
+}

--- a/src/Models/Entities/HrPerson.cs
+++ b/src/Models/Entities/HrPerson.cs
@@ -27,6 +27,9 @@ namespace Models
         /// The long name / description of the person's HR department.
         [Column("hr_department_desc")]
         public string HrDepartmentDescription { get; set; }
+
+        /// The MarkedForDelete when updating from HR Profile API
+        public bool MarkedForDelete { get; set; }
     
     }
     

--- a/src/Tasks/Buildings.cs
+++ b/src/Tasks/Buildings.cs
@@ -15,13 +15,9 @@ namespace Tasks
     {
         // Runs at 30 minutes past every hour (00:30 AM, 01:30 AM, 02:30 AM, ...)
         [FunctionName(nameof(ScheduledBuildingsUpdate))]
-        public static async Task ScheduledBuildingsUpdate([TimerTrigger("0 30 * * * *")]TimerInfo myTimer, 
+        public static Task ScheduledBuildingsUpdate([TimerTrigger("0 30 * * * *")]TimerInfo timer, 
             [DurableClient] IDurableOrchestrationClient starter)
-        {
-            string instanceId = await starter.StartNewAsync(nameof(BuildingsUpdateOrchestrator), null);
-            Logging.GetLogger(instanceId, nameof(ScheduledBuildingsUpdate), myTimer)
-               .Debug("Started scheduled buildings update.");
-        }
+            => Utils.StartOrchestratorAsSingleton(timer, starter, nameof(BuildingsUpdateOrchestrator));
 
         [FunctionName(nameof(BuildingsUpdateOrchestrator))]
         public static async Task BuildingsUpdateOrchestrator([OrchestrationTrigger] IDurableOrchestrationContext context)

--- a/src/Tasks/DTO.cs
+++ b/src/Tasks/DTO.cs
@@ -77,8 +77,8 @@ namespace Tasks
             record.NameLast = LastName;
             record.Netid = Username.ToLowerInvariant();
             record.CampusEmail = Email;
-            record.Campus = contact == null ? "" : contact.CampusCode; 
-            record.CampusPhone = contact == null ? "" : contact.PhoneNumber; 
+            record.Campus = contact?.CampusCode == null ? "" : contact.CampusCode; 
+            record.CampusPhone = contact?.PhoneNumber == null ? "" : contact.PhoneNumber; 
             record.Position = job == null ? "" : job.Position;
             record.HrDepartment = job == null ? "" : job.JobDepartmentId;
             record.HrDepartmentDescription = job == null ? "" : job.JobDepartmentDesc;

--- a/src/Tasks/Logging.cs
+++ b/src/Tasks/Logging.cs
@@ -57,11 +57,8 @@ namespace Tasks
             return logger;
         }
 
-        public static ILogger GetLogger(string functionName, object properties = null)  
-            => GetLogger("00000000-0000-0000-0000-000000000000", functionName, properties);
-
         public static ILogger GetLogger(IDurableOrchestrationContext ctx, object properties = null) 
-            => GetLogger(ctx.InstanceId, ctx.Name, properties);
+            => GetLogger(ctx.Name, properties);
 
         private static Lazy<ILogger> Logger = new Lazy<ILogger>(() => 
             new LoggerConfiguration()
@@ -71,9 +68,9 @@ namespace Tasks
                 .TryAddPostgresqlDatabaseSink(LogEventLevel.Debug)
                 .CreateLogger());
 
-        public static ILogger GetLogger(string instanceId, string function, object properties = null) 
+        public static ILogger GetLogger(string function, object properties = null) 
             => Logger.Value
-                .ForContext(LogProps.InvocationId, System.Guid.Parse(instanceId))
+                .ForContext(LogProps.InvocationId, System.Guid.Parse("00000000-0000-0000-0000-000000000000"))
                 .ForContext(LogProps.Function, function)
                 .ForContext(LogProps.Properties, properties == null ? null : JsonConvert.SerializeObject(properties, Models.Json.JsonSerializerSettings));        
     }

--- a/src/Tasks/People.cs
+++ b/src/Tasks/People.cs
@@ -137,7 +137,7 @@ namespace Tasks
             Console.WriteLine($"Fetching {type} page {page}");
             var url = Utils.Env("ImsProfileApiUrl", required: true);
             var authHeader = new AuthenticationHeaderValue("Bearer", jwt);
-            var req = new HttpRequestMessage(HttpMethod.Get, $"{url}?affiliationType={type}&page={page}&pageSize=1000");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{url}?affiliationType={type}&page={page}&pageSize=5000");
             req.Headers.Authorization = authHeader;
             var resp = await Utils.HttpClient.SendAsync(req);
             return await Utils.DeserializeResponse<ProfileResponse>(nameof(FetchProfileApiPage), resp, "fetch page from IMS Profile API");

--- a/src/Tasks/People.cs
+++ b/src/Tasks/People.cs
@@ -143,7 +143,7 @@ namespace Tasks
             Console.WriteLine($"Fetching {type} page {page}");
             var url = Utils.Env("ImsProfileApiUrl", required: true);
             var authHeader = new AuthenticationHeaderValue("Bearer", jwt);
-            var req = new HttpRequestMessage(HttpMethod.Get, $"{url}?affiliationType={type}&page={page}&pageSize=7500");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{url}?affiliationType={type}&page={page}&pageSize=500");
             req.Headers.Authorization = authHeader;
             var resp = await Utils.HttpClient.SendAsync(req);
             return await Utils.DeserializeResponse<ProfileResponse>(nameof(FetchProfileApiPage), resp, "fetch page from IMS Profile API");

--- a/src/Tasks/Tools.cs
+++ b/src/Tasks/Tools.cs
@@ -15,13 +15,9 @@ namespace Tasks
     {
         // Runs every 5 minutes)
         [FunctionName(nameof(ScheduledToolsUpdate))]
-        public static async Task ScheduledToolsUpdate([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, 
+        public static Task ScheduledToolsUpdate([TimerTrigger("0 */5 * * * *")]TimerInfo timer, 
             [DurableClient] IDurableOrchestrationClient starter)
-        {
-            string instanceId = await starter.StartNewAsync(nameof(ToolsUpdateOrchestrator), null);
-            Logging.GetLogger(instanceId, nameof(ScheduledToolsUpdate), myTimer)
-                .Debug("Started scheduled tools update.");
-        }
+            => Utils.StartOrchestratorAsSingleton(timer, starter, nameof(ToolsUpdateOrchestrator));
 
         [FunctionName(nameof(ToolsUpdateOrchestrator))]
         public static async Task ToolsUpdateOrchestrator(

--- a/src/Tasks/Utils.cs
+++ b/src/Tasks/Utils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -105,5 +106,17 @@ namespace Tasks
             }
         }
 
+        public static IEnumerable<IEnumerable<T>> Partition<T>(this IEnumerable<T> sequence, int size) {
+            List<T> partition = new List<T>(size);
+            foreach(var item in sequence) {
+                partition.Add(item);
+                if (partition.Count == size) {
+                    yield return partition;
+                    partition = new List<T>(size);
+                }
+            }
+            if (partition.Count > 0)
+                yield return partition;
+        }
     }
 }


### PR DESCRIPTION
* Reduce memory footprint by not passing Profile data between activity functions. This reduces memory overhead of the function app and eliminates storage ingress/egress of people data blobs.
* Rework HR People and Building tasks to batch upsert DB records. This reduces DB chattiness, CPU consumption, and App Insights logging.
* Implement singleton pattern for durable orchestrators, to ensure only one instance of a given task orchestration is running at any one time.
* Add unit/integration tests back to the DevOps pipeline.