### PR TITLE
Fixes #30

### DIFF
--- a/src/Models/DTO/UnitRequest.cs
+++ b/src/Models/DTO/UnitRequest.cs
@@ -17,5 +17,10 @@ namespace Models
         public int? ParentId { get; set; }
         
         public const string MalformedRequest = "The request body is malformed or missing. The Name field is required.";
+
+        public UnitRequest()
+        {
+            Description = "";
+        }
     }
 }

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -116,6 +116,14 @@ namespace Integration
                 Assert.AreEqual(req.ParentId, actual.Parent.Id);
             }
 
+            [Test]
+            public async Task CreateWithDefaultValues()
+            {
+                var req = new UnitRequest { Name = "Foo" };
+                var resp = await PostAuthenticated("units", req, ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.Created);
+            }
+
             //403 unauthorized
             [Test]
             public async Task UnauthorizedCannotCreate()


### PR DESCRIPTION
Adds a test to replicate issue.
UnitRequest's default constructor now provides an empty string for `Description` by default.