### PR TITLE
Fix unexpected blank screen / errors when browsing to deep link

### DIFF
--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -124,19 +124,19 @@ namespace API.Middleware
         private static Result<string,Error> ExtractJWT(HttpRequest request)
         {
             if (!request.Headers.ContainsKey("Authorization")) 
-                return Pipeline.BadRequest(ErrorRequestMissingAuthorizationHeader);
+                return Pipeline.Unauthorized(ErrorRequestMissingAuthorizationHeader);
             
             var authHeaders = request.Headers["Authorization"].ToArray();
             if (!authHeaders.Any()) 
-                return Pipeline.BadRequest(ErrorRequestEmptyAuthorizationHeader);
+                return Pipeline.Unauthorized(ErrorRequestEmptyAuthorizationHeader);
             
             var header = authHeaders.First();
             if (!header.StartsWith("Bearer", ignoreCase: true, culture: CultureInfo.InvariantCulture)) 
-                return Pipeline.BadRequest(ErrorRequestAuthorizationHeaderMissingBearerScheme);
+                return Pipeline.Unauthorized(ErrorRequestAuthorizationHeaderMissingBearerScheme);
 
             var bearerToken = header.Replace("Bearer", "", ignoreCase: true, culture: CultureInfo.InvariantCulture).Trim();
             if (string.IsNullOrWhiteSpace(bearerToken)) 
-                return Pipeline.BadRequest(ErrorRequestAuthorizationHeaderMissingBearerToken);
+                return Pipeline.Unauthorized(ErrorRequestAuthorizationHeaderMissingBearerToken);
             
             return Pipeline.Success(bearerToken);
         }

--- a/tests/API/Integration/AuthenticationTests.cs
+++ b/tests/API/Integration/AuthenticationTests.cs
@@ -23,7 +23,7 @@ namespace Integration
         public async Task AuthorizationHeaderRequired()
         {
             var resp = await Http.GetAsync("people");
-            AssertStatusCode(resp, HttpStatusCode.BadRequest);
+            AssertStatusCode(resp, HttpStatusCode.Unauthorized);
             var actual = await resp.Content.ReadAsAsync<ApiError>();
             Assert.AreEqual(actual.Errors.First(), "Request is missing an Authorization header.");
         }
@@ -34,7 +34,7 @@ namespace Integration
             var request = new HttpRequestMessage(HttpMethod.Get, "people");
             request.Headers.Authorization = new AuthenticationHeaderValue("some_scheme");
             var resp = await Http.SendAsync(request);
-            AssertStatusCode(resp, HttpStatusCode.BadRequest);
+            AssertStatusCode(resp, HttpStatusCode.Unauthorized);
             var actual = await resp.Content.ReadAsAsync<ApiError>();
             Assert.AreEqual(actual.Errors.First(), "Request Authorization header scheme must be \"Bearer\"");
         }
@@ -46,7 +46,7 @@ namespace Integration
             var request = new HttpRequestMessage(HttpMethod.Get, "people");
             request.Headers.Authorization = new AuthenticationHeaderValue(scheme);
             var resp = await Http.SendAsync(request);
-            AssertStatusCode(resp, HttpStatusCode.BadRequest);
+            AssertStatusCode(resp, HttpStatusCode.Unauthorized);
             var actual = await resp.Content.ReadAsAsync<ApiError>();
             Assert.AreEqual(actual.Errors.First(), "Request Authorization header contains empty \"Bearer\" token.");
         }


### PR DESCRIPTION
The API was returning HTTP 400 in case of a missing or non-bearer JWT. By sending an HTTP 401, the frontend will know to send the user to IU Login for authentication. (This was the behavior of the V1 API.)