### PR TITLE
LspContact.PreferredEmail from Unit

### DIFF
--- a/src/Models/Lsp/LspContact.cs
+++ b/src/Models/Lsp/LspContact.cs
@@ -16,7 +16,7 @@ namespace Models
             GroupInternalEmail = person.Notes ?? "";
             NetworkID = person.Netid;
             Phone = person.CampusPhone;
-            PreferredEmail = person.CampusEmail;
+            PreferredEmail = person.Notes ?? person.CampusEmail;
             IsLSPAdmin = person.IsServiceAdmin;
         }
 

--- a/src/Models/TestEntities/TestEntities.cs
+++ b/src/Models/TestEntities/TestEntities.cs
@@ -206,6 +206,7 @@ namespace Models
 			};
 
 			public const int ServiceAdminId = 4;
+			public const string ServiceAdminEmail = "admin@pawnee.in.us";
 			public static readonly Person ServiceAdmin = new Person()
 			{
 				Id = ServiceAdminId,
@@ -217,7 +218,7 @@ namespace Models
 				Location = "",
 				Campus = "Pawnee",
 				CampusPhone = "812.856.4444",
-				CampusEmail = "admin@pawnee.in.us",
+				CampusEmail = ServiceAdminEmail,
 				Expertise = "Guarding the Precious",
 				Notes = "",
 				PhotoUrl = "",
@@ -278,13 +279,14 @@ namespace Models
 		public static class Units
 		{
 			public const int CityOfPawneeUnitId = 1;
+			public const string CityOfPawneeEmail = "city@pawnee.in.us";
 			public static readonly Unit CityOfPawnee = new Unit()
 			{
 				Id = CityOfPawneeUnitId,
 				Name = "City of Pawnee",
 				Description = "City of Pawnee, Indiana",
 				Url = "http://pawneeindiana.com/",
-				Email = "city@pawnee.in.us",
+				Email = CityOfPawneeEmail,
 				ParentId = null,
 				Parent = null
 			};

--- a/tests/API/Integration/LspTests.cs
+++ b/tests/API/Integration/LspTests.cs
@@ -106,9 +106,9 @@ namespace Integration
             Assert.AreEqual(expected.CampusEmail, actual.PreferredEmail);
             Assert.AreEqual(expected.Name, actual.FullName);
             Assert.AreEqual(TestEntities.Units.CityOfPawnee.Email, actual.GroupInternalEmail);
+            Assert.AreEqual(TestEntities.Units.CityOfPawnee.Email, actual.PreferredEmail);
             Assert.True(actual.IsLSPAdmin);
         }
-
 
         private static async Task<T> DeserializeXml<T>(HttpResponseMessage resp) where T : class
         {

--- a/tests/API/Integration/LspTests.cs
+++ b/tests/API/Integration/LspTests.cs
@@ -91,24 +91,44 @@ namespace Integration
             CollectionAssert.AreEquivalent(expectedDepartments, actualDepartments);
         }
 
-        [Test]
-        public async Task GetDepartmentLSPs_Properties()
+        private async Task<LspContact> GetParksLsps()
         {
             var resp = await GetAnonymous($"LspdbWebService.svc/LspsInDept/{TestEntities.Departments.ParksName}");
             AssertStatusCode(resp, HttpStatusCode.OK);
             var arr = await DeserializeXml<LspContactArray>(resp);
             Assert.NotNull(arr);
             Assert.NotNull(arr.LspContacts);
-            var expected = TestEntities.People.ServiceAdmin; 
-            var actual = arr.LspContacts.SingleOrDefault(c => c.NetworkID == expected.Netid);            
+            var expected = TestEntities.People.ServiceAdmin;
+            return arr.LspContacts.SingleOrDefault(c => c.NetworkID == expected.Netid);
+        }
+
+        [Test]
+        public async Task GetDepartmentLSPs_Properties()
+        {
+            var expected = TestEntities.People.ServiceAdmin;
+            var actual = await GetParksLsps();
             Assert.AreEqual(expected.CampusPhone, actual.Phone);
             Assert.AreEqual(expected.CampusEmail, actual.Email);
-            Assert.AreEqual(expected.CampusEmail, actual.PreferredEmail);
+            Assert.AreEqual(TestEntities.Units.CityOfPawnee.Email ?? expected.CampusEmail, actual.PreferredEmail);
             Assert.AreEqual(expected.Name, actual.FullName);
             Assert.AreEqual(TestEntities.Units.CityOfPawnee.Email, actual.GroupInternalEmail);
-            Assert.AreEqual(TestEntities.Units.CityOfPawnee.Email, actual.PreferredEmail);
             Assert.True(actual.IsLSPAdmin);
         }
+
+        [TestCase(null, TestEntities.People.ServiceAdminEmail)]
+        [TestCase(TestEntities.Units.CityOfPawneeEmail, TestEntities.Units.CityOfPawneeEmail)]
+        public async Task GetsCorrectPreferredEmailForUnitMembers(string unitEmail, string expectedEmail)
+        {
+            var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
+            var parks = await db.Units.FindAsync(TestEntities.Units.CityOfPawneeUnitId);
+            parks.Email = unitEmail;
+            await db.SaveChangesAsync();
+
+            var actual = await GetParksLsps();
+            Assert.AreEqual(expectedEmail, actual.PreferredEmail);
+        }
+
+
 
         private static async Task<T> DeserializeXml<T>(HttpResponseMessage resp) where T : class
         {


### PR DESCRIPTION
Resolves #43
If the LSP's unit has an email that is the preferred email, otherwise default to their personal email.

* Updates existing test to reflect this change.
* Adds a test that verifies the two cases(unit with no email, and a unit with an email)