### PR TITLE
Create unit member bug

### DIFF
--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -75,7 +75,7 @@ namespace API.Data
             => db.HrPeople
                 .Where(h=>  EF.Functions.ILike(h.Netid, $"%{query.Q}%")
                             || EF.Functions.ILike(h.Name, $"%{query.Q}%"))
-                .Select(h => new PeopleLookupItem { Id = 0, Netid = h.Netid, Name = h.Name })
+                .Select(h => new PeopleLookupItem { Id = 0, NetId = h.Netid, Name = h.Name })
                 .AsNoTracking();
 
         private static IQueryable<PeopleLookupItem> SearchBothByNameOrNetId(PeopleContext db, HrPeopleSearchParameters query)
@@ -84,14 +84,14 @@ namespace API.Data
             var peopleMatches = db.People
                 .Where(p=> EF.Functions.ILike(p.Netid, $"%{query.Q}%")
                             || EF.Functions.ILike(p.Name, $"%{query.Q}%"))
-                .Select(p => new PeopleLookupItem { Id = p.Id, Netid = p.Netid, Name = p.Name })
+                .Select(p => new PeopleLookupItem { Id = p.Id, NetId = p.Netid, Name = p.Name })
                 .Take(query.Limit)
                 .AsNoTracking();
-            var existingNetIds = peopleMatches.Select(p => p.Netid.ToLower()).ToList();
+            var existingNetIds = peopleMatches.Select(p => p.NetId.ToLower()).ToList();
 
             //Get possible matches from the HrPeople table, and exclude any existing users.
             var hrPeopleMatches = SearchHrPeopleByNameOrNetId(db, query)
-                .Where(h => existingNetIds.Contains(h.Netid.ToLower()) == false)
+                .Where(h => existingNetIds.Contains(h.NetId.ToLower()) == false)
                 .Take(query.Limit);
             
             return peopleMatches

--- a/src/API/Data/UnitMembersRepository.cs
+++ b/src/API/Data/UnitMembersRepository.cs
@@ -114,7 +114,10 @@ namespace API.Data
 				Campus = hrPerson.Campus,
 				CampusPhone = hrPerson.CampusPhone,
 				CampusEmail = hrPerson.CampusEmail,
-				DepartmentId = matchingDepartment?.Id
+				DepartmentId = matchingDepartment?.Id,
+				Location = "",
+				Notes = body.Notes ?? "",
+				PhotoUrl = ""
 			};
 
 			db.People.Add(newPerson);

--- a/src/API/Data/UnitMembersRepository.cs
+++ b/src/API/Data/UnitMembersRepository.cs
@@ -116,6 +116,7 @@ namespace API.Data
 				CampusEmail = hrPerson.CampusEmail,
 				DepartmentId = matchingDepartment?.Id,
 				Location = "",
+				Expertise = "",
 				Notes = body.Notes ?? "",
 				PhotoUrl = ""
 			};

--- a/src/API/Data/UnitMembersRepository.cs
+++ b/src/API/Data/UnitMembersRepository.cs
@@ -81,18 +81,18 @@ namespace API.Data
 
 		private static async Task<Result<Person, Error>> FindOrCreatePerson(PeopleContext db, UnitMemberRequest body)
 		{
-			if (string.IsNullOrWhiteSpace(body.Netid) && body.PersonId.HasValue == false)
+			if (string.IsNullOrWhiteSpace(body.NetId) && body.PersonId.HasValue == false)
 			{
 				return Pipeline.Success<Person>(null);
 			}
 			
-			var existing = await db.People.SingleOrDefaultAsync(p => p.Id == body.PersonId || p.Netid == body.Netid);
+			var existing = await db.People.SingleOrDefaultAsync(p => p.Id == body.PersonId || p.Netid == body.NetId);
 			if (existing != null)
 			{
 				return Pipeline.Success(existing);
 			}
 
-			var hrPerson = await db.HrPeople.SingleOrDefaultAsync(p => p.Netid == body.Netid);
+			var hrPerson = await db.HrPeople.SingleOrDefaultAsync(p => p.Netid == body.NetId);
 			if (hrPerson == null)
 			{
 				return Pipeline.NotFound("The specified person does not exist in the HR directory.");

--- a/src/Models/DTO/PeopleLookupItem.cs
+++ b/src/Models/DTO/PeopleLookupItem.cs
@@ -3,7 +3,7 @@ namespace Models
 	public class PeopleLookupItem
 	{
 		public int Id {get; set;}
-		public string Netid {get; set;}
+		public string NetId {get; set;}
 		public string Name {get; set;}
 	}
 }

--- a/src/Models/DTO/UnitMemberRequest.cs
+++ b/src/Models/DTO/UnitMemberRequest.cs
@@ -16,7 +16,7 @@ namespace Models
         /// The ID of the person class. This can be null if the position is vacant.
         public int? PersonId { get; set; }
         /// The NetID of the person, if they are not already in the IT people directory. This can be null if the position is vacant.
-        public string Netid { get; set; }
+        public string NetId { get; set; }
         /// The title/position of this membership.
         public string Title { get; set; }
         /// The percentage of time allocated to this position by this person (in case of split appointments).

--- a/tests/API/Integration/UnitMembersTests.cs
+++ b/tests/API/Integration/UnitMembersTests.cs
@@ -235,6 +235,25 @@ namespace Integration
 				Assert.AreEqual(1, actual.Errors.Count);
 				Assert.Contains("The provided person is already a member of the provided unit.", actual.Errors);
 			}
+
+			[Test]
+			public async Task CreateUserFromHrPersonRecord()
+			{
+				// Based on the real request from react:
+				// {"unitId":"333","netId":"natsoto","personId":0,"title":"test","role":"Member","percentage":100}
+				var req = new UnitMemberRequest
+				{
+					UnitId = TestEntities.Units.ParksAndRecUnitId,
+					NetId = TestEntities.HrPeople.Tammy1.Netid,
+					Title = "Harridan",
+					Role = Role.Member,
+					Percentage = 100,
+				};
+				var resp = await PostAuthenticated("memberships", req, ValidAdminJwt);
+				
+				AssertStatusCode(resp, HttpStatusCode.Created);
+				var actual = await resp.Content.ReadAsAsync<UnitMemberResponse>();
+			}
 		}
 
 		public class UnitMembersEdit : ApiTest


### PR DESCRIPTION
Resolving Issues #47 and #48

The react app depends on NetId being capitalized correctly while our app frequently uses Netid. We have decided to leave the rest of the renaming alone until we rewrite the client. 

Additionally, we had issues with creating a new object with null strings instead of empty strings. The client doesn't particularly null strings either.