### PR TITLE
Improve people search

### DIFF
--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -20,33 +20,33 @@ namespace API.Data
             => ExecuteDbPipeline("search all people", async db => {
                     var parsedName = GetParsedName(query.Q);
                     var result = await GetPeopleFilteredByArea(db, query)
-                    .Where(p => // partial match netid and/or name
-                        string.IsNullOrWhiteSpace(query.Q)
-                        || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
-                        || EF.Functions.ILike(p.Name, $"%{query.Q}%")
-                        || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-                            && string.IsNullOrWhiteSpace(parsedName.lastName) == false
-                            && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
-                    .Where(p => // check for overlapping responsibilities / job classes
-                        query.Responsibilities == Responsibilities.None
-                        || ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
-                        // That & is a bitwise operator - go read-up!
-                        // https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
-                    .Where(p => // partial match any supplied interest against any self-described expertise
-                        query.Expertise.Length == 0
-                        || query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
-                    .Where(p => // partial match campus
-                        query.Campus.Length == 0
-                        || query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
-                    .Where(p => query.Roles.Length == 0
-                        || p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
-                    .Where(p => query.Permissions.Length == 0
-                        || p.UnitMemberships.Any(m => query.Permissions.Contains(m.Permissions) && m.Unit.Active))
-                    .Include(p => p.Department)
-                    .AsNoTracking()
-                    .ToListAsync();
+                        .Where(p => // partial match netid and/or name
+                            string.IsNullOrWhiteSpace(query.Q)
+                            || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
+                            || EF.Functions.ILike(p.Name, $"%{query.Q}%")
+                            || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                                && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
+                        .Where(p => // check for overlapping responsibilities / job classes
+                            query.Responsibilities == Responsibilities.None
+                            || ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
+                            // That & is a bitwise operator - go read-up!
+                            // https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
+                        .Where(p => // partial match any supplied interest against any self-described expertise
+                            query.Expertise.Length == 0
+                            || query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
+                        .Where(p => // partial match campus
+                            query.Campus.Length == 0
+                            || query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
+                        .Where(p => query.Roles.Length == 0
+                            || p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
+                        .Where(p => query.Permissions.Length == 0
+                            || p.UnitMemberships.Any(m => query.Permissions.Contains(m.Permissions) && m.Unit.Active))
+                        .Include(p => p.Department)
+                        .AsNoTracking()
+                        .ToListAsync();
                     return Pipeline.Success(result);
-                    });
+                });
 
         private static (string firstName, string lastName) GetParsedName(string nameQuery)
         {
@@ -87,7 +87,6 @@ namespace API.Data
                             )
                             SELECT id FROM parentage
                             WHERE root_id <> 1))");
-
 
         private static IQueryable<PeopleLookupItem> SearchHrPeopleByNameOrNetId(PeopleContext db, HrPeopleSearchParameters query)
         {

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -18,31 +18,46 @@ namespace API.Data
 
         internal static Task<Result<List<Person>, Error>> GetAll(PeopleSearchParameters query)
             => ExecuteDbPipeline("search all people", async db => {
-                    var result = await GetPeopleFilteredByArea(db, query)
-                        .Where(p=> // partial match netid and/or name
-                            string.IsNullOrWhiteSpace(query.Q) 
-                                || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
-                                || EF.Functions.ILike(p.Name, $"%{query.Q}%"))
-                        .Where(p=> // check for overlapping responsibilities / job classes
-                            query.Responsibilities == Responsibilities.None
-                                || ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
-                                // That & is a bitwise operator - go read-up!
-                                // https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
-                        .Where(p=> // partial match any supplied interest against any self-described expertise
-                            query.Expertise.Length == 0
-                                || query.Expertise.Select(s=>$"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
-                        .Where(p=> // partial match campus
-                            query.Campus.Length == 0
-                                || query.Campus.Select(s=>$"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
-                        .Where(p => query.Roles.Length == 0
-                                || p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
-                        .Where(p => query.Permissions.Length == 0
-                                || p.UnitMemberships.Any(m => query.Permissions.Contains(m.Permissions) && m.Unit.Active))
-                        .Include(p => p.Department)
-                        .AsNoTracking()
-                        .ToListAsync();
-                    return Pipeline.Success(result);
-                });
+				var parsedName = GetParsedName(query.Q);
+				var result = await GetPeopleFilteredByArea(db, query)
+					.Where(p => // partial match netid and/or name
+						string.IsNullOrWhiteSpace(query.Q)
+							|| EF.Functions.ILike(p.Netid, $"%{query.Q}%")
+							|| EF.Functions.ILike(p.Name, $"%{query.Q}%")
+							|| (string.IsNullOrWhiteSpace(parsedName.firstName) == false
+								&& string.IsNullOrWhiteSpace(parsedName.lastName) == false
+								&& EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
+					.Where(p => // check for overlapping responsibilities / job classes
+						query.Responsibilities == Responsibilities.None
+							|| ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
+					// That & is a bitwise operator - go read-up!
+					// https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
+					.Where(p => // partial match any supplied interest against any self-described expertise
+						query.Expertise.Length == 0
+							|| query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
+					.Where(p => // partial match campus
+						query.Campus.Length == 0
+							|| query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
+					.Where(p => query.Roles.Length == 0
+							|| p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
+					.Where(p => query.Permissions.Length == 0
+							|| p.UnitMemberships.Any(m => query.Permissions.Contains(m.Permissions) && m.Unit.Active))
+					.Include(p => p.Department)
+					.AsNoTracking()
+					.ToListAsync();
+				return Pipeline.Success(result);
+			});
+
+		private static (string firstName, string lastName) GetParsedName(string nameQuery)
+		{
+			if (string.IsNullOrWhiteSpace(nameQuery) == false && nameQuery.Count(q => q == ',') == 1)
+			{
+				//take something like Drake, Jared and make it Jared Drake, but return as (firstName, LastName) tuple
+				return (nameQuery.Substring(nameQuery.IndexOf(",") + 1).Trim(), 
+                    nameQuery.Substring(0, nameQuery.IndexOf(",") - 1).Trim());
+			}
+			return ("", "");
+		}
 
         private static IQueryable<Person> GetPeopleFilteredByArea(PeopleContext db, PeopleSearchParameters query) 
             => db.People .FromSqlInterpolated<Person>($@"

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -18,48 +18,48 @@ namespace API.Data
 
         internal static Task<Result<List<Person>, Error>> GetAll(PeopleSearchParameters query)
             => ExecuteDbPipeline("search all people", async db => {
-				var parsedName = GetParsedName(query.Q);
-				var result = await GetPeopleFilteredByArea(db, query)
-					.Where(p => // partial match netid and/or name
-						string.IsNullOrWhiteSpace(query.Q)
-							|| EF.Functions.ILike(p.Netid, $"%{query.Q}%")
-							|| EF.Functions.ILike(p.Name, $"%{query.Q}%")
-							|| (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-								&& string.IsNullOrWhiteSpace(parsedName.lastName) == false
-								&& EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
-					.Where(p => // check for overlapping responsibilities / job classes
-						query.Responsibilities == Responsibilities.None
-							|| ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
-					// That & is a bitwise operator - go read-up!
-					// https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
-					.Where(p => // partial match any supplied interest against any self-described expertise
-						query.Expertise.Length == 0
-							|| query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
-					.Where(p => // partial match campus
-						query.Campus.Length == 0
-							|| query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
-					.Where(p => query.Roles.Length == 0
-							|| p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
-					.Where(p => query.Permissions.Length == 0
-							|| p.UnitMemberships.Any(m => query.Permissions.Contains(m.Permissions) && m.Unit.Active))
-					.Include(p => p.Department)
-					.AsNoTracking()
-					.ToListAsync();
-				return Pipeline.Success(result);
-			});
+                    var parsedName = GetParsedName(query.Q);
+                    var result = await GetPeopleFilteredByArea(db, query)
+                    .Where(p => // partial match netid and/or name
+                        string.IsNullOrWhiteSpace(query.Q)
+                        || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
+                        || EF.Functions.ILike(p.Name, $"%{query.Q}%")
+                        || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                            && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                            && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
+                    .Where(p => // check for overlapping responsibilities / job classes
+                        query.Responsibilities == Responsibilities.None
+                        || ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
+                        // That & is a bitwise operator - go read-up!
+                        // https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
+                    .Where(p => // partial match any supplied interest against any self-described expertise
+                        query.Expertise.Length == 0
+                        || query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
+                    .Where(p => // partial match campus
+                        query.Campus.Length == 0
+                        || query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
+                    .Where(p => query.Roles.Length == 0
+                        || p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
+                    .Where(p => query.Permissions.Length == 0
+                        || p.UnitMemberships.Any(m => query.Permissions.Contains(m.Permissions) && m.Unit.Active))
+                    .Include(p => p.Department)
+                    .AsNoTracking()
+                    .ToListAsync();
+                    return Pipeline.Success(result);
+                    });
 
-		private static (string firstName, string lastName) GetParsedName(string nameQuery)
-		{
-			if (string.IsNullOrWhiteSpace(nameQuery) == false && nameQuery.Count(q => q == ',') == 1)
-			{
-				//take something like Drake, Jared and make it Jared Drake, but return as (firstName, LastName) tuple
-				return (nameQuery.Substring(nameQuery.IndexOf(",") + 1).Trim(), 
+        private static (string firstName, string lastName) GetParsedName(string nameQuery)
+        {
+            if (string.IsNullOrWhiteSpace(nameQuery) == false && nameQuery.Count(q => q == ',') == 1)
+            {
+                //take something like Drake, Jared and make it Jared Drake, but return as (firstName, LastName) tuple
+                return (nameQuery.Substring(nameQuery.IndexOf(",") + 1).Trim(),
                     nameQuery.Substring(0, nameQuery.IndexOf(",") - 1).Trim());
-			}
-			return ("", "");
-		}
+            }
+            return ("", "");
+        }
 
-        private static IQueryable<Person> GetPeopleFilteredByArea(PeopleContext db, PeopleSearchParameters query) 
+        private static IQueryable<Person> GetPeopleFilteredByArea(PeopleContext db, PeopleSearchParameters query)
             => db.People .FromSqlInterpolated<Person>($@"
                     SELECT DISTINCT p.*
                     FROM public.people p
@@ -87,17 +87,17 @@ namespace API.Data
                             )
                             SELECT id FROM parentage
                             WHERE root_id <> 1))");
-        
-        
+
+
         private static IQueryable<PeopleLookupItem> SearchHrPeopleByNameOrNetId(PeopleContext db, HrPeopleSearchParameters query)
-        {   
+        {
             var parsedName = GetParsedName(query.Q);
             return db.HrPeople
                 .Where(h=>  EF.Functions.ILike(h.Netid, $"%{query.Q}%")
                             || EF.Functions.ILike(h.Name, $"%{query.Q}%")
-							|| (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-								&& string.IsNullOrWhiteSpace(parsedName.lastName) == false
-								&& EF.Functions.ILike(h.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
+                            || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                                && EF.Functions.ILike(h.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
                 .Select(h => new PeopleLookupItem { Id = 0, NetId = h.Netid, Name = h.Name })
                 .AsNoTracking();
         }
@@ -109,9 +109,9 @@ namespace API.Data
             var peopleMatches = db.People
                 .Where(p=> EF.Functions.ILike(p.Netid, $"%{query.Q}%")
                             || EF.Functions.ILike(p.Name, $"%{query.Q}%")
-							|| (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-								&& string.IsNullOrWhiteSpace(parsedName.lastName) == false
-								&& EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
+                            || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                                && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
                 .Select(p => new PeopleLookupItem { Id = p.Id, NetId = p.Netid, Name = p.Name })
                 .Take(query.Limit)
                 .AsNoTracking();
@@ -121,27 +121,27 @@ namespace API.Data
             var hrPeopleMatches = SearchHrPeopleByNameOrNetId(db, query)
                 .Where(h => existingNetIds.Contains(h.NetId.ToLower()) == false)
                 .Take(query.Limit);
-            
+
             return peopleMatches
                 .Union(hrPeopleMatches)
                 .Take(query.Limit);
         }
 
-        public static Task<Result<Person, Error>> GetOne(int id) 
-            => ExecuteDbPipeline("get a person by ID", db => 
+        public static Task<Result<Person, Error>> GetOne(int id)
+            => ExecuteDbPipeline("get a person by ID", db =>
                 TryFindPerson(db, id));
-        public static Task<Result<Person, Error>> GetOne(string id) 
-            => ExecuteDbPipeline("get a person by Netid", db => 
+        public static Task<Result<Person, Error>> GetOne(string id)
+            => ExecuteDbPipeline("get a person by Netid", db =>
                 TryFindPerson(db, id));
 
         private static Result<List<UnitMember>, Error> GetActiveMemberships(Person person)
             => Pipeline.Success(person.UnitMemberships.Where(um => um.Unit.Active).ToList());
 
-        public static Task<Result<List<UnitMember>, Error>> GetMemberships(int id) 
+        public static Task<Result<List<UnitMember>, Error>> GetMemberships(int id)
             => ExecuteDbPipeline("fetch unit memberships", db =>
                 TryFindPerson(db, id)
                 .Bind(person => GetActiveMemberships(person)));
-        public static Task<Result<List<UnitMember>, Error>> GetMemberships(string username) 
+        public static Task<Result<List<UnitMember>, Error>> GetMemberships(string username)
             => ExecuteDbPipeline("fetch unit memberships", db =>
                 TryFindPerson(db, username)
                 .Bind(person => GetActiveMemberships(person)));
@@ -189,7 +189,5 @@ namespace API.Data
                     var result = await SearchBothByNameOrNetId(db, query).ToListAsync();
                     return Pipeline.Success(result);
                 });
-           
-        
     }
 }

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -22,22 +22,22 @@ namespace API.Data
                     var result = await GetPeopleFilteredByArea(db, query)
                         .Where(p => // partial match netid and/or name
                             string.IsNullOrWhiteSpace(query.Q)
-                            || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
-                            || EF.Functions.ILike(p.Name, $"%{query.Q}%")
-                            || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-                                && string.IsNullOrWhiteSpace(parsedName.lastName) == false
-                                && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
+                                || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
+                                || EF.Functions.ILike(p.Name, $"%{query.Q}%")
+                                || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                    && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                                    && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
                         .Where(p => // check for overlapping responsibilities / job classes
                             query.Responsibilities == Responsibilities.None
-                            || ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
-                            // That & is a bitwise operator - go read-up!
-                            // https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
+                                || ((int)p.Responsibilities & (int)query.Responsibilities) != 0)
+                                // That & is a bitwise operator - go read-up!
+                                // https://stackoverflow.com/questions/12988260/how-do-i-test-if-a-bitwise-enum-contains-any-values-from-another-bitwise-enum-in
                         .Where(p => // partial match any supplied interest against any self-described expertise
                             query.Expertise.Length == 0
-                            || query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
+                                || query.Expertise.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Expertise, s)))
                         .Where(p => // partial match campus
                             query.Campus.Length == 0
-                            || query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
+                                || query.Campus.Select(s => $"%{s}%").ToArray().Any(s => EF.Functions.ILike(p.Campus, s)))
                         .Where(p => query.Roles.Length == 0
                             || p.UnitMemberships.Any(m => query.Roles.Contains(m.Role) && m.Unit.Active))
                         .Where(p => query.Permissions.Length == 0

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -24,8 +24,8 @@ namespace API.Data
                             string.IsNullOrWhiteSpace(query.Q)
                                 || EF.Functions.ILike(p.Netid, $"%{query.Q}%")
                                 || EF.Functions.ILike(p.Name, $"%{query.Q}%")
-                                || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-                                    && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                                || ((string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                    || string.IsNullOrWhiteSpace(parsedName.lastName) == false)
                                     && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
                         .Where(p => // check for overlapping responsibilities / job classes
                             query.Responsibilities == Responsibilities.None
@@ -53,8 +53,8 @@ namespace API.Data
             if (string.IsNullOrWhiteSpace(nameQuery) == false && nameQuery.Count(q => q == ',') == 1)
             {
                 //take something like Drake, Jared and make it Jared Drake, but return as (firstName, LastName) tuple
-                return (nameQuery.Substring(nameQuery.IndexOf(",") + 1).Trim(),
-                    nameQuery.Substring(0, nameQuery.IndexOf(",") - 1).Trim());
+                var parts = nameQuery.Split(',').Select(q => q.Trim()).ToArray();
+                return (parts[1], parts[0]);
             }
             return ("", "");
         }
@@ -94,8 +94,8 @@ namespace API.Data
             return db.HrPeople
                 .Where(h=>  EF.Functions.ILike(h.Netid, $"%{query.Q}%")
                             || EF.Functions.ILike(h.Name, $"%{query.Q}%")
-                            || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-                                && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                            || ((string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                || string.IsNullOrWhiteSpace(parsedName.lastName) == false)
                                 && EF.Functions.ILike(h.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
                 .Select(h => new PeopleLookupItem { Id = 0, NetId = h.Netid, Name = h.Name })
                 .AsNoTracking();
@@ -108,8 +108,8 @@ namespace API.Data
             var peopleMatches = db.People
                 .Where(p=> EF.Functions.ILike(p.Netid, $"%{query.Q}%")
                             || EF.Functions.ILike(p.Name, $"%{query.Q}%")
-                            || (string.IsNullOrWhiteSpace(parsedName.firstName) == false
-                                && string.IsNullOrWhiteSpace(parsedName.lastName) == false
+                            || ((string.IsNullOrWhiteSpace(parsedName.firstName) == false
+                                || string.IsNullOrWhiteSpace(parsedName.lastName) == false)
                                 && EF.Functions.ILike(p.Name, $"{parsedName.firstName}%{parsedName.lastName}%")))
                 .Select(p => new PeopleLookupItem { Id = p.Id, NetId = p.Netid, Name = p.Name })
                 .Take(query.Limit)

--- a/src/Models/TestEntities/TestEntities.cs
+++ b/src/Models/TestEntities/TestEntities.cs
@@ -152,7 +152,7 @@ namespace Models
 			{
 				Id = RSwansonId,
 				Netid = "rswanso",
-				Name = "Swanson, Ron",
+				Name = "Ron Swanson",
 				NameFirst = "Ron",
 				NameLast = "Swanson",
 				Position = "Parks and Rec Director",

--- a/tests/API/Integration/PeopleTests.cs
+++ b/tests/API/Integration/PeopleTests.cs
@@ -68,6 +68,11 @@ namespace Integration
             }
 
             [TestCase("Ron", Description="Name match")]
+            [TestCase("Swanson,Ron", Description="Alternate format match")]
+            [TestCase("Swanson, Ron", Description="Alternate format with space match")]
+            [TestCase("Swanso, Ro", Description="Alternate format partial match")]
+            [TestCase(" Swanson  ,   Ron ", Description="Alternate format match with weird spacing")]
+            [TestCase("Ron Swanson", Description="Strict format match")]
             [TestCase("Ro", Description="Partial name match")]
             public async Task CanSearchByName(string name)
             {

--- a/tests/API/Integration/PeopleTests.cs
+++ b/tests/API/Integration/PeopleTests.cs
@@ -326,6 +326,23 @@ namespace Integration
                 Assert.AreEqual(2, actual.Count);
             }
             
+            [TestCase("Swanson, Ron", 1)]
+            [TestCase("Swanson, Ro", 1)]
+            [TestCase("  Swanson,  Ron  ", 1)]
+            [TestCase("Swanson", 2)]
+            [TestCase("Swanso", 2)]
+            [TestCase("Ron Swanson", 1)]
+            [TestCase("Tammy1", 1)]
+            [TestCase("Tamm", 1)]
+            public async Task WorksWithAlternateFormat(string q, int results)
+            {
+                //Searching for "Swan" should get Ron from the People table, and Tammy Swanson form the HrPeople table.
+                var resp = await GetAuthenticated($"people-lookup?q={q}");
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                var actual = await resp.Content.ReadAsAsync<List<PeopleLookupItem>>();
+                Assert.AreEqual(results, actual.Count);
+            }
+            
             [TestCase(1)]
             [TestCase(5)]
             [TestCase(15)]

--- a/tests/API/Integration/PeopleTests.cs
+++ b/tests/API/Integration/PeopleTests.cs
@@ -74,6 +74,8 @@ namespace Integration
             [TestCase(" Swanson  ,   Ron ", Description="Alternate format match with weird spacing")]
             [TestCase("Ron Swanson", Description="Strict format match")]
             [TestCase("Ro", Description="Partial name match")]
+            [TestCase(",   Ron ", Description="Alternate format match with weird spacing")]
+            [TestCase("Swanson  ,", Description="Alternate format match with weird spacing")]
             public async Task CanSearchByName(string name)
             {
                 var resp = await GetAuthenticated($"people?q={name}");
@@ -85,13 +87,13 @@ namespace Integration
             }
 
             [TestCase(
-                Responsibilities.ItLeadership, 
+                Responsibilities.ItLeadership,
                 new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
             [TestCase(
-                Responsibilities.ItProjectMgt, 
+                Responsibilities.ItProjectMgt,
                 new int[]{ TestEntities.People.LKnopeId, TestEntities.People.BWyattId })]
             [TestCase(
-                Responsibilities.ItLeadership | Responsibilities.ItProjectMgt, 
+                Responsibilities.ItLeadership | Responsibilities.ItProjectMgt,
                 new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId })]
             [TestCase(
                 Responsibilities.BizSysAnalysis,
@@ -134,8 +136,8 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 var actual = await resp.Content.ReadAsAsync<List<Person>>();
                 AssertIdsMatchContent(expectedMatches, actual);
-            }           
-           
+            }
+
             [TestCase("Leader", new int[]{ TestEntities.People.RSwansonId, TestEntities.People.ServiceAdminId }, Description = "Return group Leader(s)")]
             [TestCase("Sublead", new int[]{ TestEntities.People.LKnopeId }, Description = "Return group Subleader(s)")]
             [TestCase("Member", new int[]{ TestEntities.People.BWyattId }, Description = "Return group Member(s)")]
@@ -148,7 +150,7 @@ namespace Integration
                 var actual = await resp.Content.ReadAsAsync<List<Person>>();
                 AssertIdsMatchContent(expectedMatches, actual);
             }
-            
+
             [TestCase("Owner", new int[]{ TestEntities.People.RSwansonId })]
             [TestCase("Viewer", new int[]{ TestEntities.People.LKnopeId })]
             [TestCase("ManageMembers", new int[]{ TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId })]
@@ -171,7 +173,7 @@ namespace Integration
                 var resp = await GetAuthenticated($"people?area={areas}");
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 var actual = await resp.Content.ReadAsAsync<List<Person>>();
-                AssertIdsMatchContent(expectedMatches, actual);                
+                AssertIdsMatchContent(expectedMatches, actual);
             }
         }
 
@@ -260,8 +262,8 @@ namespace Integration
         public class UpdatePerson : ApiTest
         {
             private static readonly PersonUpdateRequest TestUpdateRequest = new PersonUpdateRequest
-            { 
-                Location = "Timbuktu", 
+            {
+                Location = "Timbuktu",
                 Expertise = "Woodworking; Honor; Managering",
                 PhotoUrl = "http://flavorwire.files.wordpress.com/2011/11/ron-swanson-NEW.jpg",
                 Responsibilities = Responsibilities.ItLeadership & Responsibilities.ItProjectMgt,
@@ -325,7 +327,7 @@ namespace Integration
                 var actual = await resp.Content.ReadAsAsync<List<PeopleLookupItem>>();
                 Assert.AreEqual(2, actual.Count);
             }
-            
+
             [TestCase("Swanson, Ron", 1)]
             [TestCase("Swanson, Ro", 1)]
             [TestCase("  Swanson,  Ron  ", 1)]
@@ -334,6 +336,8 @@ namespace Integration
             [TestCase("Ron Swanson", 1)]
             [TestCase("Tammy1", 1)]
             [TestCase("Tamm", 1)]
+            [TestCase(",  Ron", 1)]
+            [TestCase("swanson,", 2)]
             public async Task WorksWithAlternateFormat(string q, int results)
             {
                 //Searching for "Swan" should get Ron from the People table, and Tammy Swanson form the HrPeople table.
@@ -342,7 +346,7 @@ namespace Integration
                 var actual = await resp.Content.ReadAsAsync<List<PeopleLookupItem>>();
                 Assert.AreEqual(results, actual.Count);
             }
-            
+
             [TestCase(1)]
             [TestCase(5)]
             [TestCase(15)]


### PR DESCRIPTION
When searching for people based on
`{LastName}, {FirstName}`
split it into a tuple of 
`(firstName, lastName)`
so that the query can do a wildcard search using our standard name format
`{First Name}%{LastName}%`
