### PR TITLE
Make Expertise and Responsibilities Modals Their Own Components

### DIFF
--- a/src/Web/Pages/PersonProfile.razor
+++ b/src/Web/Pages/PersonProfile.razor
@@ -60,7 +60,7 @@
                                             <div><strong>Phone: </strong>@UpdatedPerson.CampusPhone</div>
                                             <div><strong>Department: </strong><a href="/departments/@UpdatedPerson.DepartmentId">@UpdatedPerson.Department.Name</a></div>
                                         </div>
-                                    </div>
+                                    </div>                                   
                                     <div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
                                         <div>
                                             <div style="float: right;">
@@ -87,7 +87,7 @@
                                                 }
                                         </div>
                                     </div>
-                                    <ProfileExpertise CrudPerms=CrudPerms Person=UpdatedPerson />
+                                    <ProfileExpertise CrudPerms=CrudPerms @bind-Person=UpdatedPerson />
                                 </ChildContent>                                                                                                             
                             </ProfileContactInformation>
                             <ProfileUnitsHelper Title="IT Units">

--- a/src/Web/Pages/PersonProfile.razor
+++ b/src/Web/Pages/PersonProfile.razor
@@ -61,32 +61,9 @@
                                             <div><strong>Department: </strong><a href="/departments/@UpdatedPerson.DepartmentId">@UpdatedPerson.Department.Name</a></div>
                                         </div>
                                     </div>                                   
-                                    <div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
-                                        <div>
-                                            <div style="float: right;">
-                                                @if(CrudPerms.HasFlag(EntityPermissions.Post))
-                                                {
-                                                    <button type="button" title="Edit Responsibilities" class="rvt-button rvt-button--plain" data-modal-trigger="modal-form-r" @onclick=@(() => ResponsibilitiesInput = UpdatedPerson.Responsibilities)>
-                                                        <rvt-icon name="pencil" />
-                                                        <span class="rvt-m-left-xs rvt-sr-only">Edit Responsibilities</span>
-                                                    </button>
-                                                }
-                                                
-                                                <ModalForm Id="modal-form-r" Title="Edit Responsibilities" SubmitButtonText="Update" Item=@UpdatedPerson.Responsibilities OnSubmit=@UpdateResponsibilities @ref=form>
-                                                    <RivetInputFlag @bind-Value="ResponsibilitiesInput" Description="Check all the relevant responsibilities performed"  Inline=@inline />
-                                                </ModalForm>
-                                            </div>
-                                            <h2 class="rvt-ts-23 rvt-text-bold">Responsibilities</h2>
-                                            <p>What kinds of work do you do on a day-to-day basis?</p>
-
-                                                @foreach (var item in UpdatedPerson.Responsibilities.ToString().Split(',').Select(r => r.Trim()))
-                                                {
-                                                    <ul class="rvt-list rvt-plain-list">
-                                                        <li>@GetEnumDisplayName(item)</li>
-                                                    </ul>
-                                                }
-                                        </div>
-                                    </div>
+                                    
+                                    <ProfileResponsibilities CrudPerms=CrudPerms @bind-Person=UpdatedPerson />
+                                    
                                     <ProfileExpertise CrudPerms=CrudPerms @bind-Person=UpdatedPerson />
                                 </ChildContent>                                                                                                             
                             </ProfileContactInformation>
@@ -137,31 +114,18 @@
 @code {
     private EntityPermissions CrudPerms;
     private Exception GeneralException;
-    private Exception ModalException;
-    private AuthenticatedUser LoggedInUser;
     private Person UpdatedPerson = new Person();
     private IEnumerable<UnitResponse> ProfileUnits = new List<UnitResponse>();
     private IEnumerable<UnitMemberResponse> Memberships = new List<UnitMemberResponse>();
     private string _PrevNetId = null;
     [Parameter] public string NetId { get; set; }
-    private EditContext FormContext;
-    private bool inline = false;
     private HttpClient Api() => ClientFactory.CreateClient("Api");
-    private Responsibilities ResponsibilitiesInput;
-    private ModalForm<Responsibilities> form;
-    private HttpResponseMessage formResponse = null;
     private bool isExpanded = false;
-    private bool isInterestEntered = false;
-    private string EnteredTerm;
-    private string EnteredValue;
     private string ProfileName;
     protected bool ShowLoader = false;
     protected IDisposable Loading()
         => new DisposableLoader(s => ShowLoader = s, StateHasChanged);
-    protected override async Task OnInitializedAsync()
-    {
 
-    }
     protected override async Task OnParametersSetAsync()
     {
         if(NetId != _PrevNetId)
@@ -219,63 +183,6 @@
             return;
         }
     }
-    private async Task UpdateResponsibilities()
-    {
-        try
-        {
-            await UpdatePerson(UpdatedPerson);
-        }
-        catch (Exception ex)
-        {
-            ModalException = ex;
-        }
-        StateHasChanged();
-    }
-    public string GetEnumDisplayName(string enumValue)
-    {
-        var fieldInfo = UpdatedPerson.Responsibilities.GetType().GetFields();
-        var field = fieldInfo.FirstOrDefault(f => f.Name == enumValue);
-        return field != null ? field.GetCustomAttribute<DisplayAttribute>()?.GetName() ?? field.Name : enumValue;
-    }
     
-    private async Task UpdatePerson(Person member)
-    {
-        member.Responsibilities = ResponsibilitiesInput;
-
-        if (member.Responsibilities.ToString().Split(',').Count() == 0 && member.Netid == NetId)
-        {
-            var postContent = new StringContent(JsonConvert.SerializeObject(member), System.Text.Encoding.UTF8, "application/json");
-            formResponse = await Api().PostAsync($"/people/", postContent);
-        }
-        else if (member.Expertise.Split(',').Count() == 0 && member.Netid == NetId)
-        {
-            var postContent = new StringContent(JsonConvert.SerializeObject(member), System.Text.Encoding.UTF8, "application/json");
-            formResponse = await Api().PostAsync($"/people/", postContent);
-        }
-        else if (member.Netid == NetId)
-        {
-            string memberOutput = JsonConvert.SerializeObject(member, Json.JsonSerializerSettings);
-            var deserializedMember = JsonConvert.DeserializeObject<Person>(memberOutput, Json.JsonSerializerSettings);
-            deserializedMember.Responsibilities = member.Responsibilities;
-            deserializedMember.Expertise = member.Expertise;            
-            var putContent = new StringContent(JsonConvert.SerializeObject(deserializedMember), System.Text.Encoding.UTF8, "application/json");
-            formResponse = await Api().PutAsync($"/people/{deserializedMember.Id}", putContent);
-        }
-       
-
-        if (formResponse.IsSuccessStatusCode == true)
-        {
-            string responsemsg = await formResponse.Content.ReadAsStringAsync();
-            UpdatedPerson = JsonConvert.DeserializeObject<Person>(responsemsg, Json.JsonSerializerSettings);
-            await form.Close();
-            await InterestsModalFormClose();
-        }
-    }
-
-    public async Task InterestsModalFormClose()
-    {
-        await JSRuntime.InvokeVoidAsync("Modal.close", "modal-form-i");
-    }
-
     public void Dispose() { }
 }

--- a/src/Web/Pages/PersonProfile.razor
+++ b/src/Web/Pages/PersonProfile.razor
@@ -87,95 +87,7 @@
                                                 }
                                         </div>
                                     </div>
-                                    <div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
-                                        <div>
-                                            <div style="float: right;">         
-                                                @if(CrudPerms.HasFlag(EntityPermissions.Post))
-                                                {
-                                                    <button title=Edit Interests class="rvt-button rvt-button--plain" data-modal-trigger="modal-form-i">
-                                                        <rvt-icon name="pencil" />
-                                                        <span class="rvt-m-left-xs rvt-sr-only">Edit Interests</span>
-                                                    </button>
-                                                }
-                                                <div class="rvt-modal" id="modal-form-i" role="dialog" aria-labelledby="modal-form-i-title" aria-hidden="true" tabindex="-1" current="">
-                                                    <div class="rvt-modal__inner">
-                                                        <header class="rvt-modal__header">
-                                                            <h1 class="rvt-modal__title" id="modal-form-title">Edit Interests</h1>
-                                                        </header>
-                                                        <div class="rvt-modal__body">
-                                                            <EditForm EditContext="@FormContext">
-                                                                <DataAnnotationsValidator />
-                                                                    <div>
-                                                                        @if (isInterestEntered && !string.IsNullOrEmpty(UpdatedPerson.Expertise))
-                                                                        {
-                                                                            <ul class="rvt-list rvt-plain-list rvt-inline-list">
-                                                                                @foreach (var Interest in UpdatedPerson.Expertise.Split(","))
-                                                                                {
-                                                                                    <li>
-                                                                                        <span class="rvt-badge">@Interest
-                                                                                            <button type="button" id="@Interest" class="rvt-button rvt-button--plain rvt-p-all-xxs" title="remove" style="height: auto;" @onclick="@(()=> RemoveInterests(Interest))" @onkeypress:preventDefault>
-                                                                                                <rvt-icon name="trash"></rvt-icon><span class="rvt-sr-only">trash</span>
-                                                                                            </button>
-                                                                                        </span>
-                                                                                    </li>
-                                                                                }
-                                                                            </ul>
-                                                                        }
-                                                                    </div>
-                                                                    <div>
-                                                                        <div class="rvt-input rvt-m-bottom-sm">
-                                                                            <label for="modal-form-i" class="">Search</label>
-                                                                            <div class="rvt-input-group">
-                                                                                <input class=@(EnteredTerm==null ? "" : "rvt-validation-success") id="modal-form-i" type='text' onfocus="this.value=''" value=" " @oninput="(e) => {AddEnteredValue(e.Value.ToString());}" @onkeypress="@KeyPressHandler"/>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                    @if (EnteredValue != null)
-                                                                    {
-                                                                        <div class="rvt-dropdown__menu" aria-hidden="false" style="position: relative; padding: 0px;">
-                                                                            <div>
-                                                                                <button type="button" id="@EnteredValue-modal-form-i" class="rvt-button" @onclick=@(() => UpdateInterests(EnteredValue)) >@EnteredValue </button>
-                                                                            </div>
-                                                                             @if (EnteredTerm != null)
-                                                                            {
-                                                                                @foreach (var enteredItem in EnteredTerm.Split(","))
-                                                                                {
-                                                                                    <div>
-                                                                                        <button type="button" id="@enteredItem-modal-form-i" class="rvt-button" @onclick=@(() => UpdateInterests(enteredItem)) >@enteredItem </button>
-                                                                                    </div>
-                                                                                }
-                                                                            }    
-                                                                        </div>
-                                                                    }
-                                                                                                                                      
-                                                                       
-                                                            </EditForm>
-                                                        </div>
-
-                                                        <button type="button" class="rvt-button rvt-modal__close" data-modal-close="modal-form-i">                                                        
-                                                            <rvt-icon name="close" /><span class="rvt-sr-only">close</span>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <h2 class="rvt-ts-23 rvt-text-bold">Professional interests</h2>
-                                            <p>What kinds of skills, technologies, or languages do you want to work with or learn about?</p>
-                                                <ul class="rvt-list rvt-plain-list rvt-inline-list">
-                                                    @if (UpdatedPerson.Expertise != null)
-                                                    {
-                                                        @foreach (var Interest in UpdatedPerson.Expertise.Split(","))
-                                                        {
-                                                            <li><span class="rvt-badge">@Interest</span></li>
-                                                        }
-                                                    }
-                                                    else
-                                                    {
-                                                        <li></li>
-                                                    }                                                    
-                                                </ul>
-
-                                        </div>
-                                    </div>
+                                    <ProfileExpertise CrudPerms=CrudPerms Person=UpdatedPerson />
                                 </ChildContent>                                                                                                             
                             </ProfileContactInformation>
                             <ProfileUnitsHelper Title="IT Units">
@@ -232,7 +144,6 @@
     private IEnumerable<UnitMemberResponse> Memberships = new List<UnitMemberResponse>();
     private string _PrevNetId = null;
     [Parameter] public string NetId { get; set; }
-    private List<string> InterestList = new List<string>();
     private EditContext FormContext;
     private bool inline = false;
     private HttpClient Api() => ClientFactory.CreateClient("Api");
@@ -249,7 +160,7 @@
         => new DisposableLoader(s => ShowLoader = s, StateHasChanged);
     protected override async Task OnInitializedAsync()
     {
-        FormContext = new EditContext(InterestList);
+
     }
     protected override async Task OnParametersSetAsync()
     {
@@ -271,12 +182,6 @@
             string responsemsg = await response.Content.ReadAsStringAsync();
             UpdatedPerson = JsonConvert.DeserializeObject<Person>(responsemsg, Json.JsonSerializerSettings);
             ProfileName = UpdatedPerson.Name;
-            InterestList.Clear();           
-            if(UpdatedPerson.Expertise != null && UpdatedPerson.Netid == NetId)
-            {
-                InterestList.AddRange(UpdatedPerson.Expertise.Split(","));
-                isInterestEntered = true;            
-            }
         }
         else
         {
@@ -332,65 +237,10 @@
         var field = fieldInfo.FirstOrDefault(f => f.Name == enumValue);
         return field != null ? field.GetCustomAttribute<DisplayAttribute>()?.GetName() ?? field.Name : enumValue;
     }
-    private async Task AddEnteredValue(string Value)
-    {
-        @* The API we are using to get the tech tags : https://api.stackexchange.com/2.2/tags?order=desc&site=stackoverflow&min=4000&sort=popular&inname=vuejs *@
-        EnteredValue = Value; 
-        using (var client = new HttpClient())
-        {
-            var response = await client.GetAsync($"https://api.stackexchange.com/2.2/tags?order=desc&site=stackoverflow&min=4000&sort=popular&inname={HttpUtility.UrlEncode(Value)}");
-            if (response.IsSuccessStatusCode)
-            {
-                var responsemsg = await response.Content.ReadAsStringAsync();
-                var jsonResponse = JObject.Parse(responsemsg);
-                var jItems = (JArray)jsonResponse["items"];
-                var interestsTags = jItems.Select(i => (string)i["name"]).ToList();
-                EnteredTerm = string.Join(",", interestsTags);
-            }
-        }        
-        isInterestEntered = true;
-    }
-    private async Task RemoveInterests(string interest)
-    {
-        InterestList.Remove(interest);
-        if (InterestList.Count() != 0)
-        {
-            UpdatedPerson.Expertise = InterestList.Aggregate((a, b) => a + "," + b);        
-        }
-        else
-        {
-            UpdatedPerson.Expertise = null;
-            isInterestEntered = false;
-        }       
-        await InterestsModalFormClose();
-    }
-    private void KeyPressHandler(KeyboardEventArgs e)
-    {
-        if (e.Code == "Enter" || e.Code == "NumpadEnter")
-        {            
-            if(EnteredValue != null)
-            UpdateInterests(EnteredValue);
-        }
-    }  
-    private async Task UpdateInterests(string selectedInterest)
-    {
-        InterestList.Add(selectedInterest);
-        try
-        {
-            await UpdatePerson(UpdatedPerson);
-        }
-        catch (Exception ex)
-        {
-            ModalException = ex;
-        }
-
-        StateHasChanged();
-    }
-
+    
     private async Task UpdatePerson(Person member)
     {
         member.Responsibilities = ResponsibilitiesInput;
-        member.Expertise = InterestList.Aggregate((a,b) => a + "," + b);
 
         if (member.Responsibilities.ToString().Split(',').Count() == 0 && member.Netid == NetId)
         {

--- a/src/Web/Shared/ModalForm.razor
+++ b/src/Web/Shared/ModalForm.razor
@@ -12,7 +12,7 @@
         <header class="rvt-modal__header">
             <h1 class="rvt-modal__title" id="modal-form-title">@Title</h1>
         </header>
-        <div class="rvt-modal__body">
+        <div class="rvt-modal__body rvt-p-lr-md">
             <EditForm OnValidSubmit="DoSubmit" EditContext="@editContext">
                 <DataAnnotationsValidator />
                 <div class="rvt-p-bottom-md">

--- a/src/Web/Shared/ModalForm.razor
+++ b/src/Web/Shared/ModalForm.razor
@@ -70,7 +70,7 @@
 
     ///<summary> When true display a confirmation message before closing the modal.</summary>
     [Parameter]
-	public bool ConfirmBeforeClose { get; set; } = false;
+    public bool ConfirmBeforeClose { get; set; } = false;
 
     private bool formInvalid = true;
     private bool submitting = false;

--- a/src/Web/Shared/ModalForm.razor
+++ b/src/Web/Shared/ModalForm.razor
@@ -71,6 +71,10 @@
     [Parameter]
     public RenderFragment ChildContent { get; set; }
 
+    ///<summary> When true display a confirmation message before closing the modal.</summary>
+    [Parameter]
+	public bool ConfirmBeforeClose { get; set; } = false;
+
     private bool formInvalid = true;
     private bool submitting = false;
     
@@ -88,9 +92,37 @@
         StateHasChanged();
     }
 
+    protected override async Task OnParametersSetAsync()
+    {
+        if(ConfirmBeforeClose)
+        {
+            await AddToModalConfirmBeforeCloseList();
+        }
+        else
+        {
+            RemoveFromModalConfirmBeforeCloseList();
+        }
+    }
+
+    private async Task AddToModalConfirmBeforeCloseList()
+    {
+        // Add Id to the collection defined in interop.js
+        await JSRuntime.InvokeVoidAsync("modalsConfirmBeforeClose.push", Id);
+    }
+
+    private void RemoveFromModalConfirmBeforeCloseList()
+    {
+        // Cast JSRuntime so we can use InvokeVoid, instead of InvokeVoidAsync
+        var js = (IJSInProcessRuntime)JSRuntime;
+        // Remove Id from the collection defined in interop.js
+        js.InvokeVoid("removeModalConfirmBeforeClose", Id);
+    }
+
     public void Dispose()
     {
         editContext.OnFieldChanged -= HandleFieldChanged;
+        // Make sure we remove Id from the collection of modals to watch in interop.js
+        RemoveFromModalConfirmBeforeCloseList();
     }
 
     public void ResetState()
@@ -115,6 +147,12 @@
     private async Task DoSubmit()
     {
         submitting = true;
+        // Ignore ConfirmBeforeClose while submitting.
+        if(ConfirmBeforeClose)
+        {
+            RemoveFromModalConfirmBeforeCloseList();
+        }
+
         try
         {
             await OnSubmit();
@@ -122,6 +160,11 @@
         finally
         {
             submitting = false;
+            // If ConfirmBeforeClose is true re-enable it.
+            if(ConfirmBeforeClose)
+            {
+                await AddToModalConfirmBeforeCloseList();
+            }
         }
     }
 

--- a/src/Web/Shared/ModalForm.razor
+++ b/src/Web/Shared/ModalForm.razor
@@ -106,6 +106,11 @@
         submitting = false;
 
     }
+
+    public void ForceValid()
+    {
+        formInvalid = false;
+    }
     
     private async Task DoSubmit()
     {

--- a/src/Web/Shared/ModalForm.razor
+++ b/src/Web/Shared/ModalForm.razor
@@ -19,20 +19,23 @@
                     @* All the form inputs are rendered here. *@
                     @ChildContent
                 </div>
-                <div class="rvt-modal__controls">
-                    <button type="submit" class="rvt-button" disabled="@(formInvalid || submitting)">
-                        @if(submitting)
-                        {
-                            <div class="rvt-loader rvt-display-inline-block" aria-label="Submitting"></div>
-                            <span class="rvt-m-left-xs">@SubmitButtonText</span>
-                        }
-                        else
-                        {
-                            @SubmitButtonText
-                        }
-                    </button>
-                    @* <button type="button" class="rvt-button rvt-button--secondary" data-modal-close=@Id>Cancel</button> *@
-                </div>
+                @if(string.IsNullOrWhiteSpace(SubmitButtonText) == false)
+                {
+                    <div class="rvt-modal__controls">
+                        <button type="submit" class="rvt-button" disabled="@(formInvalid || submitting)">
+                            @if(submitting)
+                            {
+                                <div class="rvt-loader rvt-display-inline-block" aria-label="Submitting"></div>
+                                <span class="rvt-m-left-xs">@SubmitButtonText</span>
+                            }
+                            else
+                            {
+                                @SubmitButtonText
+                            }
+                        </button>
+                        @* <button type="button" class="rvt-button rvt-button--secondary" data-modal-close=@Id>Cancel</button> *@
+                    </div>
+                }
             </EditForm>
         </div>
         <button type="button" class="rvt-button rvt-modal__close" data-modal-close=@Id>

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -11,7 +11,7 @@
 		<div class="rvt-m-left-sm">
 			@if(CrudPerms.HasFlag(EntityPermissions.Post))
 			{
-				<button title="Edit Interests" class="rvt-button rvt-button--plain" data-modal-trigger="modal-form-expertise">
+				<button title="Edit Interests" class="rvt-button rvt-button--plain" data-modal-trigger="modal-form-expertise" @onclick=ResetForm>
 					<rvt-icon name="pencil" />
 					<span class="rvt-m-left-xs rvt-sr-only">Edit Interests</span>
 				</button>
@@ -29,45 +29,41 @@
 		}
 	</ul>
 </div>
-<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="Update" Item=@SearchTerm OnSubmit=@KeyPressHandler @ref=Mf>
+<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="" Item=@SearchTerm OnSubmit=@KeyPressHandler @ref=Mf>
 	<DisplayException Ex=@Ex />
-	<EditForm EditContext="@FormContext">
-		<DataAnnotationsValidator />
 			
-		<ul class="rvt-list rvt-plain-list rvt-inline-list">
-			@foreach (var Interest in (Person.Expertise ?? "").Split(","))
-			{
-				<li>
-					<span class="rvt-badge">@Interest
-						<button type="button" class="rvt-button rvt-button--plain rvt-p-all-xxs" title="remove" style="height: auto;" @onclick="@(()=> RemoveInterest(Interest))" @onkeypress:preventDefault>
-							<rvt-icon name="trash"></rvt-icon><span class="rvt-sr-only">trash</span>
-						</button>
-					</span>
-				</li>
-			}
-		</ul>
-		
-		<div>
-			<div class="rvt-input rvt-m-bottom-sm">
-				<label for="modal-form-i" class="">Search</label>
-				<div class="rvt-input-group">
-					<input class=@(EnteredTerm==null ? "" : "rvt-validation-success") id="modal-form-i" type='text' onfocus="this.value=''" value=" " @oninput="(e) => {AddEnteredValue(e.Value.ToString());}" @onkeypress="@KeyPressHandler"/>
-				</div>
+	<ul class="rvt-list rvt-plain-list rvt-inline-list">
+		@foreach (var Interest in (Person.Expertise ?? "").Split(","))
+		{
+			<li>
+				<span class="rvt-badge">@Interest
+					<button type="button" class="rvt-button rvt-button--plain rvt-p-all-xxs" title="remove" style="height: auto;" @onclick="@(()=> RemoveInterest(Interest))" @onkeypress:preventDefault>
+						<rvt-icon name="trash"></rvt-icon><span class="rvt-sr-only">trash</span>
+					</button>
+				</span>
+			</li>
+		}
+	</ul>
+	
+	@* <div>
+		<div class="rvt-input rvt-m-bottom-sm">
+			<label for="modal-form-i" class="">Search</label>
+			<div class="rvt-input-group">
+				<input class=@(EnteredTerm==null ? "" : "rvt-validation-success") id="modal-form-i" type='text' onfocus="this.value=''" value=" " @oninput="(e) => {AddEnteredValue(e.Value.ToString());}" @onkeypress="@KeyPressHandler"/>
 			</div>
 		</div>
-		
-		@if(string.IsNullOrWhiteSpace(EnteredTerm) == false)
+	</div> *@
+	<RivetInputText @bind-Value="SearchTerm" Label="Search" Placeholder="Type an Interest" Description="Type an interest and then click a button in the results below to add it to this profile." />
+	
+	
+	<ul class="rvt-plain-list rvt-border-all rvt-border-radius">
+		@foreach (var enteredItem in Suggestions)
 		{
-			<ul class="rvt-plain-list rvt-border-all rvt-border-radius">
-				@foreach (var enteredItem in EnteredTerm.Split(","))
-				{
-					<li>
-						<a class="rvt-button rvt-button--secondary rvt-button--full-width" @onclick=@(() => AddInterest(enteredItem)) >@enteredItem </a>
-					</li>
-				}
-			</ul>
+			<li>
+				<a class="rvt-button rvt-button--secondary rvt-button--full-width" @onclick=@(() => AddInterest(enteredItem)) >@enteredItem </a>
+			</li>
 		}
-	</EditForm>
+	</ul>
 </ModalForm>
 
 
@@ -79,18 +75,17 @@
 
 	private string SearchTerm = "";
 	private ModalForm<string> Mf;
-	private EditContext FormContext;
 	private List<string> Suggestions = new List<string>();
 	private Exception Ex;
 
 	//Temp stuff we'll ditch
 	private string EnteredTerm = "";
-	//End temp stuff
-
-	protected override async Task OnInitializedAsync()
+	private void ResetForm()
 	{
-		FormContext = new EditContext(SearchTerm);
+		Suggestions = new List<string>();
+		SearchTerm = "";
 	}
+	//End temp stuff
 
 	private async Task RemoveInterest(string interest)
 	{

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -33,7 +33,7 @@
 		}
 	</ul>
 </div>
-<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="Save Changes" Item=@ExpertiseAsList OnSubmit=@SaveChanges @ref=Mf>
+<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="Save Changes" Item=@ExpertiseAsList OnSubmit=@SaveChanges ConfirmBeforeClose=@ConfirmModalClose @ref=Mf>
 	<DisplayException Ex=@Ex />
 	<ul class="rvt-list rvt-plain-list rvt-inline-list">
 		@foreach (var Interest in ExpertiseAsList)
@@ -72,6 +72,7 @@
 	private List<string> ExpertiseAsList = new List<string>();
 	private string SearchTerm = "";
 	private ModalForm<List<string>> Mf;
+	private bool ConfirmModalClose = false;
 	private List<string> Suggestions = new List<string>();
 	private StackExchangeRequest SuggestionsRequest;
 	private Exception Ex;
@@ -96,7 +97,8 @@
 			.ToList();
 		Suggestions = new List<string>();
 		SearchTerm = "";
-		
+		ConfirmModalClose = false;
+
 		Mf.ResetState();
 	}
 
@@ -104,7 +106,9 @@
 	{	
 		ExpertiseAsList.Remove(interest);
 		
-		// We've made a change ensure that the submit button is available.
+		// We've made a change, confirm closing the modal without saving changes.
+		ConfirmModalClose = true;
+		// Ensure that the submit button is available.
 		Mf.ForceValid();
 	}
 
@@ -119,7 +123,9 @@
 		SearchTerm = "";
 		SearchTermChanged(SearchTerm);
 
-		// We've made a change ensure that the submit button is available.
+		// We've made a change, confirm closing the modal without saving changes.
+		ConfirmModalClose = true;
+		// Ensure that the submit button is available.
 		Mf.ForceValid();
 	}
 

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -40,7 +40,7 @@
 		{
 			<li>
 				<span class="rvt-badge">@Interest
-					<button type="button" class="rvt-button rvt-button--plain rvt-p-all-xxs" title="remove" style="height: auto;" @onclick="@(()=> RemoveInterest(Interest))" @onkeypress:preventDefault>
+					<button type="button" class="rvt-button rvt-button--plain rvt-p-all-xxs" title="remove" style="height: auto;" @onclick="@(()=> RemoveInterest(Interest))">
 						<rvt-icon name="trash"></rvt-icon><span class="rvt-sr-only">trash</span>
 					</button>
 				</span>
@@ -48,7 +48,7 @@
 		}
 	</ul>
 	
-	<RivetInputText @bind-Value="SearchTerm" Label="Search" Placeholder="Type an Interest" Description="Type an interest and then click a button in the results below to add it to this profile." @oninput="e => SearchTermChanged(e.Value.ToString())" />
+	<RivetInputText @bind-Value="SearchTerm" Label="Search" Placeholder="Type an Interest" Description="Type an interest and then click a button in the results below to add it to this profile." @oninput="e => SearchTermChanged(e.Value.ToString())" @onkeydown=SearchTermListenForEnter/>
 	
 	
 	<ul class="rvt-plain-list rvt-border-all rvt-border-radius">
@@ -73,6 +73,7 @@
 	private string SearchTerm = "";
 	private ModalForm<List<string>> Mf;
 	private bool ConfirmModalClose = false;
+	private bool AddedByEnter = false;
 	private List<string> Suggestions = new List<string>();
 	private StackExchangeRequest SuggestionsRequest;
 	private Exception Ex;
@@ -98,7 +99,9 @@
 		Suggestions = new List<string>();
 		SearchTerm = "";
 		ConfirmModalClose = false;
+		AddedByEnter = false;
 
+		CancelSuggestionsRequestIfRunning();
 		Mf.ResetState();
 	}
 
@@ -114,6 +117,11 @@
 
 	private async Task AddInterest(string interest)
 	{
+		if(string.IsNullOrWhiteSpace(interest))
+		{
+			return;
+		}
+
 		if(ExpertiseAsList.Contains(interest.Trim().ToLower()) == false)
 		{
 			ExpertiseAsList.Add(interest.Trim().ToLower());
@@ -127,6 +135,15 @@
 		ConfirmModalClose = true;
 		// Ensure that the submit button is available.
 		Mf.ForceValid();
+	}
+
+	private void SearchTermListenForEnter(KeyboardEventArgs e)
+	{
+		if (e.Code == "Enter" || e.Code == "NumpadEnter")
+		{
+			AddedByEnter = true;
+			AddInterest(SearchTerm);
+		}
 	}
 
 	private async Task SaveChanges()
@@ -159,7 +176,13 @@
 			}
 			
 			// Everything updated, close the modal
-			Mf.Close();
+			if(AddedByEnter == false)
+			{
+				Mf.Close();
+			}
+			
+			// We've saved our changes reset the bools that dicate the ModalForms behavior.
+			ResetForm();
 		}
 		catch(Exception ex)
 		{
@@ -171,6 +194,7 @@
 	private async Task SearchTermChanged(string newValue)
 	{
 		//Console.WriteLine($"SearchTerm({SearchTerm}) changing to: {newValue}");
+		SearchTerm = newValue;
 		await UpdateSuggestions(newValue);
 	}
 
@@ -191,6 +215,15 @@
 		public List<SuggestionItem> Items { get; set; }
 	}
 
+	private void CancelSuggestionsRequestIfRunning()
+	{
+		var acceptableTaskStatus = new List<TaskStatus> { TaskStatus.RanToCompletion, TaskStatus.Canceled };
+		if(SuggestionsRequest != null && acceptableTaskStatus.Contains(SuggestionsRequest.Task.Status) == false)
+		{
+			SuggestionsRequest.TokenSource.Cancel();
+		}
+	}
+
 	private async Task UpdateSuggestions(string searchTerm)
 	{
 		if(string.IsNullOrWhiteSpace(searchTerm))
@@ -200,11 +233,7 @@
 		}
 
 		// Cancel any currently running requests to the Stack Exchange API that are currently running.
-		var acceptableTaskStatus = new List<TaskStatus> { TaskStatus.RanToCompletion, TaskStatus.Canceled };
-		if(SuggestionsRequest != null && acceptableTaskStatus.Contains(SuggestionsRequest.Task.Status) == false)
-		{
-			SuggestionsRequest.TokenSource.Cancel();
-		}
+		CancelSuggestionsRequestIfRunning();
 
 		// Make a cancelable request to the API and process the response.
 		var ts = new CancellationTokenSource();

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -173,6 +173,9 @@
 			if(AddedByEnter == false)
 			{
 				Mf.Close();
+			} else
+			{
+				ConfirmModalClose = false;
 			}
 
 			// Invoking after close because the two-way binding can cause hiccups in the ModalForm.

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -24,11 +24,17 @@
 	</div>
 	<p>What kinds of skills, technologies, or languages do you want to work with or learn about?</p>
 	<ul class="rvt-list rvt-plain-list rvt-inline-list">
-		@if (Person.Expertise != null)
+		@if (string.IsNullOrWhiteSpace(Person.Expertise))
+		{
+			<li><em>None</em></li>
+		} else
 		{
 			@foreach (var Interest in Person.Expertise.Split(","))
 			{
-				<li><span class="rvt-badge">@Interest</span></li>
+				@if(string.IsNullOrWhiteSpace(Interest) == false)
+				{
+					<li><span class="rvt-badge">@Interest</span></li>
+				}
 			}
 		}
 	</ul>
@@ -83,10 +89,16 @@
 
 	private void ResetForm()
 	{
-		ExpertiseAsList = Person.Expertise
-			.Split(",")
-			.Select(e => e.Trim().ToLower())
-			.ToList();
+		ExpertiseAsList = new List<string>();
+		if(string.IsNullOrWhiteSpace(Person.Expertise) == false)
+		{
+			ExpertiseAsList.AddRange(
+				Person.Expertise
+					.Split(",")
+					.Select(e => e.Trim().ToLower())
+					.Where(e => string.IsNullOrWhiteSpace(e) == false)
+			);
+		}
 		SearchTerm = "";
 		ConfirmModalClose = false;
 		AddedByEnter = false;

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -3,6 +3,8 @@
 @using Models.Enums;
 @using System.Threading;
 @using System.Web;
+@using Newtonsoft.Json;
+@inject IHttpClientFactory ClientFactory;
 @implements IDisposable;
 
 <div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
@@ -66,6 +68,7 @@
 	[Parameter]
 	public Person Person { get; set; }
 
+	private HttpClient Api() => ClientFactory.CreateClient("Api");
 	private List<string> ExpertiseAsList = new List<string>();
 	private string SearchTerm = "";
 	private ModalForm<List<string>> Mf;
@@ -103,8 +106,6 @@
 		
 		// We've made a change ensure that the submit button is available.
 		Mf.ForceValid();
-
-		Ex = new NotImplementedException("RemoveInterest()");
 	}
 
 	private async Task AddInterest(string interest)
@@ -114,16 +115,51 @@
 			ExpertiseAsList.Add(interest.Trim().ToLower());
 		}
 
+		// Reset the search term and clear-out suggestions.
+		SearchTerm = "";
+		SearchTermChanged(SearchTerm);
+
 		// We've made a change ensure that the submit button is available.
 		Mf.ForceValid();
-
-		Ex = new NotImplementedException();
 	}
 
 	private async Task SaveChanges()
 	{
-		// This is where we send the requested changes up to API.
-		Ex = new NotImplementedException(nameof(SaveChanges));
+		try
+		{
+			// Make an in-memory copy of Person to PUT to the server.
+			var objToPut = JsonConvert.DeserializeObject<Person>(JsonConvert.SerializeObject(Person, Json.JsonSerializerSettings), Json.JsonSerializerSettings);
+			// Update objToPut's Expertise
+			objToPut.Expertise = string.Join(",", ExpertiseAsList);
+
+			var url = $"/people/{Person.Id}";
+
+			using (var apiClient = Api())
+			{
+				var reqJson = JsonConvert.SerializeObject(objToPut, Json.JsonSerializerSettings);
+				var reqContent = new StringContent(reqJson, System.Text.Encoding.UTF8, "application/json");
+				var response = await apiClient.PutAsync(url, reqContent);
+
+				if(response.IsSuccessStatusCode == false)
+				{
+					throw new Exception($"An error({response.StatusCode}) was encountered attempting to PUT to {url}");
+				}
+
+				// The Response is a Person object, use it to update our Person variable
+				var stringResult = await response.Content.ReadAsStringAsync();
+				var result = JsonConvert.DeserializeObject<Person>(stringResult, Json.JsonSerializerSettings);
+				
+				Person = result;
+			}
+			
+			// Everything updated, close the modal
+			Mf.Close();
+		}
+		catch(Exception ex)
+		{
+			Ex = ex;
+		}
+		StateHasChanged();// Force it to redraw the component since the Expertise entries are drawn procedurally.
 	}
 
 	private async Task SearchTermChanged(string newValue)

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -81,11 +81,6 @@
 	private StackExchangeRequest SuggestionsRequest;
 	private Exception Ex;
 
-	protected override async Task OnParametersSetAsync()
-	{
-		Console.WriteLine($"From Expertise OnParametersSetAsync\n\tExpertise: {Person.Expertise}\n\tResponsibilities: {Person.Responsibilities}");
-	}
-
 	private void ResetForm()
 	{
 		ExpertiseAsList = Person.Expertise
@@ -174,14 +169,11 @@
 			// Everything updated, close the modal
 			if(AddedByEnter == false)
 			{
-				Console.WriteLine($"ConfirmModalClose: {ConfirmModalClose}");
 				Mf.Close();
 			}
 
-			if(result != null)
-			{
-				await PersonChanged.InvokeAsync(result);
-			}
+			// Invoking after close because the two-way binding can cause hiccups in the ModalForm.
+			await PersonChanged.InvokeAsync(result);
 			
 			// We've saved our changes reset the bools that dicate the ModalForms behavior.
 			ResetForm();

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -67,6 +67,9 @@
 	public EntityPermissions CrudPerms { get; set; }
 	[Parameter]
 	public Person Person { get; set; }
+	// Enable two-way binding.
+	[Parameter]
+    public EventCallback<Person> PersonChanged { get; set; }
 
 	private HttpClient Api() => ClientFactory.CreateClient("Api");
 	private List<string> ExpertiseAsList = new List<string>();
@@ -78,18 +81,11 @@
 	private StackExchangeRequest SuggestionsRequest;
 	private Exception Ex;
 
-	//Temp stuff we'll ditch
-	private string EnteredTerm = "";
-	private async Task AddEnteredValue(string value)
+	protected override async Task OnParametersSetAsync()
 	{
-		Ex = new NotImplementedException();
+		Console.WriteLine($"From Expertise OnParametersSetAsync\n\tExpertise: {Person.Expertise}\n\tResponsibilities: {Person.Responsibilities}");
 	}
 
-	private async Task KeyPressHandler()
-	{
-		Ex = new NotImplementedException();
-	}
-	//End temp stuff
 	private void ResetForm()
 	{
 		ExpertiseAsList = Person.Expertise
@@ -150,6 +146,8 @@
 	{
 		try
 		{
+			Person result;
+
 			// Make an in-memory copy of Person to PUT to the server.
 			var objToPut = JsonConvert.DeserializeObject<Person>(JsonConvert.SerializeObject(Person, Json.JsonSerializerSettings), Json.JsonSerializerSettings);
 			// Update objToPut's Expertise
@@ -165,20 +163,24 @@
 
 				if(response.IsSuccessStatusCode == false)
 				{
-					throw new Exception($"An error({response.StatusCode}) was encountered attempting to PUT to {url}");
+					throw new Exception($"An error({response.StatusCode}) was encountered attempting to PUT Expertise to {url}");
 				}
 
 				// The Response is a Person object, use it to update our Person variable
 				var stringResult = await response.Content.ReadAsStringAsync();
-				var result = JsonConvert.DeserializeObject<Person>(stringResult, Json.JsonSerializerSettings);
-				
-				Person = result;
+				result = JsonConvert.DeserializeObject<Person>(stringResult, Json.JsonSerializerSettings);
 			}
 			
 			// Everything updated, close the modal
 			if(AddedByEnter == false)
 			{
+				Console.WriteLine($"ConfirmModalClose: {ConfirmModalClose}");
 				Mf.Close();
+			}
+
+			if(result != null)
+			{
+				await PersonChanged.InvokeAsync(result);
 			}
 			
 			// We've saved our changes reset the bools that dicate the ModalForms behavior.

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -27,7 +27,8 @@
 		@if (string.IsNullOrWhiteSpace(Person.Expertise))
 		{
 			<li><em>None</em></li>
-		} else
+		}
+		else
 		{
 			@foreach (var Interest in Person.Expertise.Split(","))
 			{

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -56,15 +56,17 @@
 	
 	<RivetInputText @bind-Value="SearchTerm" Label="Search" Placeholder="Type an Interest" Description="Type an interest and then click a button in the results below to add it to this profile." @oninput="e => SearchTermChanged(e.Value.ToString())" @onkeydown=SearchTermListenForEnter/>
 	
-	
-	<ul class="rvt-plain-list rvt-border-all rvt-border-radius">
-		@foreach (var enteredItem in Suggestions)
-		{
-			<li>
-				<a class="rvt-button rvt-button--secondary rvt-button--full-width" @onclick=@(() => AddInterest(enteredItem)) >@enteredItem </a>
-			</li>
-		}
-	</ul>
+	@if(Suggestions.Count > 0)
+	{
+		<ul class="rvt-plain-list rvt-border-all rvt-border-radius rvt-m-top-xs rvt-p-bottom-xs">
+			@foreach (var enteredItem in Suggestions)
+			{
+				<li>
+					<a class="rvt-button rvt-button--secondary rvt-button--full-width" @onclick=@(() => AddInterest(enteredItem)) >@enteredItem </a>
+				</li>
+			}
+		</ul>
+	}
 </ModalForm>
 
 

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -1,6 +1,8 @@
 @using RivetBlazor.Components
 @using Models;
 @using Models.Enums;
+@using System.Threading;
+@using System.Web;
 @implements IDisposable;
 
 <div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
@@ -45,15 +47,7 @@
 		}
 	</ul>
 	
-	@* <div>
-		<div class="rvt-input rvt-m-bottom-sm">
-			<label for="modal-form-i" class="">Search</label>
-			<div class="rvt-input-group">
-				<input class=@(EnteredTerm==null ? "" : "rvt-validation-success") id="modal-form-i" type='text' onfocus="this.value=''" value=" " @oninput="(e) => {AddEnteredValue(e.Value.ToString());}" @onkeypress="@KeyPressHandler"/>
-			</div>
-		</div>
-	</div> *@
-	<RivetInputText @bind-Value="SearchTerm" Label="Search" Placeholder="Type an Interest" Description="Type an interest and then click a button in the results below to add it to this profile." />
+	<RivetInputText @bind-Value="SearchTerm" Label="Search" Placeholder="Type an Interest" Description="Type an interest and then click a button in the results below to add it to this profile." @oninput="e => SearchTermChanged(e.Value.ToString())" />
 	
 	
 	<ul class="rvt-plain-list rvt-border-all rvt-border-radius">
@@ -76,6 +70,7 @@
 	private string SearchTerm = "";
 	private ModalForm<string> Mf;
 	private List<string> Suggestions = new List<string>();
+	private StackExchangeRequest SuggestionsRequest;
 	private Exception Ex;
 
 	//Temp stuff we'll ditch
@@ -105,6 +100,86 @@
 	private async Task AddInterest(string interest)
 	{
 		Ex = new NotImplementedException();
+	}
+
+	private async Task SearchTermChanged(string newValue)
+	{
+		//Console.WriteLine($"SearchTerm({SearchTerm}) changing to: {newValue}");
+		await UpdateSuggestions(newValue);
+	}
+
+	private class StackExchangeRequest
+	{
+		public Task Task { get; set; }
+		public CancellationTokenSource TokenSource { get; set; }
+	}
+
+	private class SuggestionItem
+	{
+		public double Count { get; set; }
+		public string Name { get; set; }
+	}
+
+	private class SuggestionResponse
+	{
+		public List<SuggestionItem> Items { get; set; }
+	}
+
+	private async Task UpdateSuggestions(string searchTerm)
+	{
+		if(string.IsNullOrWhiteSpace(searchTerm))
+		{
+			return;
+		}
+
+		// Cancel any currently running requests to the Stack Exchange API that are currently running.
+		var acceptableTaskStatus = new List<TaskStatus> { TaskStatus.RanToCompletion, TaskStatus.Canceled };
+		if(SuggestionsRequest != null && acceptableTaskStatus.Contains(SuggestionsRequest.Task.Status) == false)
+		{
+			SuggestionsRequest.TokenSource.Cancel();
+		}
+
+		// Make a cancelable request to the API and process the response.
+		var ts = new CancellationTokenSource();
+		SuggestionsRequest = new StackExchangeRequest
+		{
+			TokenSource = ts,
+			Task = Task.Run(async () => {
+				// Pause before sending the request in case the user isn't done typing.
+				// Additional keystrokes will cancel this request.
+				await Task.Delay(500);
+				
+				if(ts.Token.IsCancellationRequested == false)// Only procede if this task has not been canceled.
+				{
+					// Using a new client instead of API so we don't send the users bearer token to Stack Exchange
+					using (var client = new HttpClient())
+					{
+						var response = await client.GetAsync($"https://api.stackexchange.com/2.2/tags?order=desc&site=stackoverflow&min=4000&sort=popular&inname={HttpUtility.UrlEncode(searchTerm.ToLower())}");
+						// If this task was canceled before we got a response do not update Suggestions.
+						if(ts.Token.IsCancellationRequested == false)
+						{
+							if(response.IsSuccessStatusCode)
+							{
+								var result = await response.Content.ReadFromJsonAsync<SuggestionResponse>();
+								
+								//Make sure the user's input is the first item in the list, with no duplicates.
+								var rawSuggestions = result.Items.Select(i => i.Name).ToList();
+								rawSuggestions.Remove(searchTerm.ToLower());
+								rawSuggestions.Insert(0, searchTerm.ToLower());
+								
+								Suggestions = rawSuggestions.Take(10).ToList();
+							}
+							else
+							{
+								Suggestions = new List<string> { searchTerm.ToLower() };
+							}
+						}
+					}
+				}
+			}, ts.Token)
+		};
+
+		await SuggestionsRequest.Task;
 	}
 
 	public void Dispose() { }

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -1,0 +1,116 @@
+@using RivetBlazor.Components
+@using Models;
+@using Models.Enums;
+@implements IDisposable;
+
+<div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
+	<div class="rvt-flex">
+		<div class="rvt-grow-1">
+			<h2 class="rvt-ts-23 rvt-text-bold">Professional interests</h2>
+		</div>
+		<div class="rvt-m-left-sm">
+			@if(CrudPerms.HasFlag(EntityPermissions.Post))
+			{
+				<button title="Edit Interests" class="rvt-button rvt-button--plain" data-modal-trigger="modal-form-expertise">
+					<rvt-icon name="pencil" />
+					<span class="rvt-m-left-xs rvt-sr-only">Edit Interests</span>
+				</button>
+			}
+		</div>
+	</div>
+	<p>What kinds of skills, technologies, or languages do you want to work with or learn about?</p>
+	<ul class="rvt-list rvt-plain-list rvt-inline-list">
+		@if (Person.Expertise != null)
+		{
+			@foreach (var Interest in Person.Expertise.Split(","))
+			{
+				<li><span class="rvt-badge">@Interest</span></li>
+			}
+		}
+	</ul>
+</div>
+<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="Update" Item=@SearchTerm OnSubmit=@KeyPressHandler @ref=Mf>
+	<DisplayException Ex=@Ex />
+	<EditForm EditContext="@FormContext">
+		<DataAnnotationsValidator />
+			
+		<ul class="rvt-list rvt-plain-list rvt-inline-list">
+			@foreach (var Interest in (Person.Expertise ?? "").Split(","))
+			{
+				<li>
+					<span class="rvt-badge">@Interest
+						<button type="button" class="rvt-button rvt-button--plain rvt-p-all-xxs" title="remove" style="height: auto;" @onclick="@(()=> RemoveInterest(Interest))" @onkeypress:preventDefault>
+							<rvt-icon name="trash"></rvt-icon><span class="rvt-sr-only">trash</span>
+						</button>
+					</span>
+				</li>
+			}
+		</ul>
+		
+		<div>
+			<div class="rvt-input rvt-m-bottom-sm">
+				<label for="modal-form-i" class="">Search</label>
+				<div class="rvt-input-group">
+					<input class=@(EnteredTerm==null ? "" : "rvt-validation-success") id="modal-form-i" type='text' onfocus="this.value=''" value=" " @oninput="(e) => {AddEnteredValue(e.Value.ToString());}" @onkeypress="@KeyPressHandler"/>
+				</div>
+			</div>
+		</div>
+		
+		@if(string.IsNullOrWhiteSpace(EnteredTerm) == false)
+		{
+			<ul class="rvt-plain-list rvt-border-all rvt-border-radius">
+				@foreach (var enteredItem in EnteredTerm.Split(","))
+				{
+					<li>
+						<a class="rvt-button rvt-button--secondary rvt-button--full-width" @onclick=@(() => AddInterest(enteredItem)) >@enteredItem </a>
+					</li>
+				}
+			</ul>
+		}
+	</EditForm>
+</ModalForm>
+
+
+@code{
+	[Parameter]
+	public EntityPermissions CrudPerms { get; set; }
+	[Parameter]
+	public Person Person { get; set; }
+
+	private string SearchTerm = "";
+	private ModalForm<string> Mf;
+	private EditContext FormContext;
+	private List<string> Suggestions = new List<string>();
+	private Exception Ex;
+
+	//Temp stuff we'll ditch
+	private string EnteredTerm = "";
+	//End temp stuff
+
+	protected override async Task OnInitializedAsync()
+	{
+		FormContext = new EditContext(SearchTerm);
+	}
+
+	private async Task RemoveInterest(string interest)
+	{
+		Ex = new NotImplementedException("RemoveInterest()");
+	}
+
+	private async Task AddEnteredValue(string value)
+	{
+		Ex = new NotImplementedException();
+	}
+
+	private async Task KeyPressHandler()
+	{
+		Ex = new NotImplementedException();
+	}
+
+	private async Task AddInterest(string interest)
+	{
+		Ex = new NotImplementedException();
+	}
+
+	public void Dispose() { }
+}

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -69,7 +69,7 @@
 	public Person Person { get; set; }
 	// Enable two-way binding.
 	[Parameter]
-    public EventCallback<Person> PersonChanged { get; set; }
+	public EventCallback<Person> PersonChanged { get; set; }
 
 	private HttpClient Api() => ClientFactory.CreateClient("Api");
 	private List<string> ExpertiseAsList = new List<string>();
@@ -87,12 +87,13 @@
 			.Split(",")
 			.Select(e => e.Trim().ToLower())
 			.ToList();
-		Suggestions = new List<string>();
 		SearchTerm = "";
 		ConfirmModalClose = false;
 		AddedByEnter = false;
 
 		CancelSuggestionsRequestIfRunning();
+		Suggestions = new List<string>();
+		
 		Mf.ResetState();
 	}
 
@@ -100,7 +101,7 @@
 	{	
 		ExpertiseAsList.Remove(interest);
 		
-		// We've made a change, confirm closing the modal without saving changes.
+		// We've made a change, confirm before closing the modal without saving changes.
 		ConfirmModalClose = true;
 		// Ensure that the submit button is available.
 		Mf.ForceValid();
@@ -122,7 +123,7 @@
 		SearchTerm = "";
 		SearchTermChanged(SearchTerm);
 
-		// We've made a change, confirm closing the modal without saving changes.
+		// We've made a change, confirm before closing the modal without saving changes.
 		ConfirmModalClose = true;
 		// Ensure that the submit button is available.
 		Mf.ForceValid();
@@ -134,6 +135,8 @@
 		{
 			AddedByEnter = true;
 			AddInterest(SearchTerm);
+			// I wasn't able to prevent pressing enter from also submitting the ModalForm
+			// So after this runs SaveChanges() will run immediately after it.
 		}
 	}
 
@@ -182,7 +185,6 @@
 		{
 			Ex = ex;
 		}
-		StateHasChanged();// Force it to redraw the component since the Expertise entries are drawn procedurally.
 	}
 
 	private async Task SearchTermChanged(string newValue)
@@ -226,7 +228,7 @@
 			return;
 		}
 
-		// Cancel any currently running requests to the Stack Exchange API that are currently running.
+		// Cancel any currently running requests to the Stack Exchange API.
 		CancelSuggestionsRequestIfRunning();
 
 		// Make a cancelable request to the API and process the response.

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -31,11 +31,10 @@
 		}
 	</ul>
 </div>
-<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="" Item=@SearchTerm OnSubmit=@KeyPressHandler @ref=Mf>
+<ModalForm Id="modal-form-expertise" Title="Edit Interests" SubmitButtonText="Save Changes" Item=@ExpertiseAsList OnSubmit=@SaveChanges @ref=Mf>
 	<DisplayException Ex=@Ex />
-			
 	<ul class="rvt-list rvt-plain-list rvt-inline-list">
-		@foreach (var Interest in (Person.Expertise ?? "").Split(","))
+		@foreach (var Interest in ExpertiseAsList)
 		{
 			<li>
 				<span class="rvt-badge">@Interest
@@ -67,26 +66,15 @@
 	[Parameter]
 	public Person Person { get; set; }
 
+	private List<string> ExpertiseAsList = new List<string>();
 	private string SearchTerm = "";
-	private ModalForm<string> Mf;
+	private ModalForm<List<string>> Mf;
 	private List<string> Suggestions = new List<string>();
 	private StackExchangeRequest SuggestionsRequest;
 	private Exception Ex;
 
 	//Temp stuff we'll ditch
 	private string EnteredTerm = "";
-	private void ResetForm()
-	{
-		Suggestions = new List<string>();
-		SearchTerm = "";
-	}
-	//End temp stuff
-
-	private async Task RemoveInterest(string interest)
-	{
-		Ex = new NotImplementedException("RemoveInterest()");
-	}
-
 	private async Task AddEnteredValue(string value)
 	{
 		Ex = new NotImplementedException();
@@ -96,10 +84,46 @@
 	{
 		Ex = new NotImplementedException();
 	}
+	//End temp stuff
+	private void ResetForm()
+	{
+		ExpertiseAsList = Person.Expertise
+			.Split(",")
+			.Select(e => e.Trim().ToLower())
+			.ToList();
+		Suggestions = new List<string>();
+		SearchTerm = "";
+		
+		Mf.ResetState();
+	}
+
+	private async Task RemoveInterest(string interest)
+	{	
+		ExpertiseAsList.Remove(interest);
+		
+		// We've made a change ensure that the submit button is available.
+		Mf.ForceValid();
+
+		Ex = new NotImplementedException("RemoveInterest()");
+	}
 
 	private async Task AddInterest(string interest)
 	{
+		if(ExpertiseAsList.Contains(interest.Trim().ToLower()) == false)
+		{
+			ExpertiseAsList.Add(interest.Trim().ToLower());
+		}
+
+		// We've made a change ensure that the submit button is available.
+		Mf.ForceValid();
+
 		Ex = new NotImplementedException();
+	}
+
+	private async Task SaveChanges()
+	{
+		// This is where we send the requested changes up to API.
+		Ex = new NotImplementedException(nameof(SaveChanges));
 	}
 
 	private async Task SearchTermChanged(string newValue)
@@ -129,6 +153,7 @@
 	{
 		if(string.IsNullOrWhiteSpace(searchTerm))
 		{
+			Suggestions = new List<string>();
 			return;
 		}
 

--- a/src/Web/Shared/ProfileExpertise.razor
+++ b/src/Web/Shared/ProfileExpertise.razor
@@ -125,10 +125,19 @@
 		{
 			return;
 		}
-
-		if(ExpertiseAsList.Contains(interest.Trim().ToLower()) == false)
+		
+		// If interest includes a comma it is actually multiple interests at once.
+		var newInterests = interest
+			.Split(",")
+			.Select(e => e.Trim().ToLower())
+			.Where(e => string.IsNullOrWhiteSpace(e) == false);
+		
+		foreach(var i in newInterests)
 		{
-			ExpertiseAsList.Add(interest.Trim().ToLower());
+			if(ExpertiseAsList.Contains(i.Trim().ToLower()) == false)
+			{
+				ExpertiseAsList.Add(i.Trim().ToLower());
+			}
 		}
 
 		// Reset the search term and clear-out suggestions.

--- a/src/Web/Shared/ProfileResponsibilities.razor
+++ b/src/Web/Shared/ProfileResponsibilities.razor
@@ -26,7 +26,6 @@
 			</ModalForm>
 		</div>
 		<h2 class="rvt-ts-23 rvt-text-bold">Responsibilities</h2>
-		<p>@ConfirmClose</p>
 		<p>What kinds of work do you do on a day-to-day basis?</p>
 
 			@foreach (var item in Person.Responsibilities.ToString().Split(',').Select(r => r.Trim()))

--- a/src/Web/Shared/ProfileResponsibilities.razor
+++ b/src/Web/Shared/ProfileResponsibilities.razor
@@ -44,7 +44,7 @@
 	public Person Person { get; set; }
 	// Enable two-way binding.
 	[Parameter]
-    public EventCallback<Person> PersonChanged { get; set; }
+	public EventCallback<Person> PersonChanged { get; set; }
 
 	private HttpClient Api() => ClientFactory.CreateClient("Api");
 	private ModalForm<Responsibilities> Mf;
@@ -64,8 +64,8 @@
 	
 	private void ResetForm()
 	{
-		ResponsibilitiesInput = (Responsibilities)((int)Person.Responsibilities);
-		ValueAtOpen = (Responsibilities)((int)Person.Responsibilities);
+		ResponsibilitiesInput = Person.Responsibilities;
+		ValueAtOpen = Person.Responsibilities;
 
 		Mf.ResetState();
 	}
@@ -112,7 +112,6 @@
 		{
 			Ex = ex;
 		}
-		StateHasChanged();// Force it to redraw the component since the Expertise entries are drawn procedurally.
 	}
 
 	public void Dispose() { }

--- a/src/Web/Shared/ProfileResponsibilities.razor
+++ b/src/Web/Shared/ProfileResponsibilities.razor
@@ -1,0 +1,120 @@
+@using RivetBlazor.Components
+@using Models;
+@using Models.Enums;
+@using System.Threading;
+@using System.Web;
+@using Newtonsoft.Json;
+@using System.ComponentModel.DataAnnotations;
+@using System.Reflection;
+@inject IHttpClientFactory ClientFactory;
+@implements IDisposable;
+
+<div class="rvt-border-bottom rvt-m-bottom-lg rvt-p-bottom-lg">
+	<div>
+		<div style="float: right;">
+			@if(CrudPerms.HasFlag(EntityPermissions.Post))
+			{
+				<button type="button" title="Edit Responsibilities" class="rvt-button rvt-button--plain" data-modal-trigger="modal-form-r" @onclick=@(() => ResetForm())>
+					<rvt-icon name="pencil" />
+					<span class="rvt-m-left-xs rvt-sr-only">Edit Responsibilities</span>
+				</button>
+			}
+			
+			<ModalForm Id="modal-form-r" Title="Edit Responsibilities" SubmitButtonText="Save Changes" Item=@Person.Responsibilities OnSubmit=@SaveChanges ConfirmBeforeClose=@ConfirmClose @ref=Mf>
+				<DisplayException Ex=@Ex />
+				<RivetInputFlag @bind-Value="ResponsibilitiesInput" Description="Check all the relevant responsibilities performed"  Inline=false />
+			</ModalForm>
+		</div>
+		<h2 class="rvt-ts-23 rvt-text-bold">Responsibilities</h2>
+		<p>@ConfirmClose</p>
+		<p>What kinds of work do you do on a day-to-day basis?</p>
+
+			@foreach (var item in Person.Responsibilities.ToString().Split(',').Select(r => r.Trim()))
+			{
+				<ul class="rvt-list rvt-plain-list">
+					<li>@GetEnumDisplayName(item)</li>
+				</ul>
+			}
+	</div>
+</div>
+
+@code {
+	[Parameter]
+	public EntityPermissions CrudPerms { get; set; }
+	[Parameter]
+	public Person Person { get; set; }
+	// Enable two-way binding.
+	[Parameter]
+    public EventCallback<Person> PersonChanged { get; set; }
+
+	private HttpClient Api() => ClientFactory.CreateClient("Api");
+	private ModalForm<Responsibilities> Mf;
+
+	private Responsibilities ResponsibilitiesInput;
+	private Responsibilities ValueAtOpen;
+	private bool ConfirmClose => ResponsibilitiesInput != ValueAtOpen;
+	
+	private Exception Ex;
+
+	private string GetEnumDisplayName(string enumValue)
+	{
+		var fieldInfo = Person.Responsibilities.GetType().GetFields();
+		var field = fieldInfo.FirstOrDefault(f => f.Name == enumValue);
+		return field != null ? field.GetCustomAttribute<DisplayAttribute>()?.GetName() ?? field.Name : enumValue;
+	}
+	
+	private void ResetForm()
+	{
+		ResponsibilitiesInput = (Responsibilities)((int)Person.Responsibilities);
+		ValueAtOpen = (Responsibilities)((int)Person.Responsibilities);
+
+		Mf.ResetState();
+	}
+
+	private async Task SaveChanges()
+	{
+		try
+		{
+			Person result;
+
+			// Make an in-memory copy of Person to PUT to the server.
+			var objToPut = JsonConvert.DeserializeObject<Person>(JsonConvert.SerializeObject(Person, Json.JsonSerializerSettings), Json.JsonSerializerSettings);
+			// Update objToPut's Expertise
+			objToPut.Responsibilities = ResponsibilitiesInput;
+
+			var url = $"/people/{Person.Id}";
+
+			using (var apiClient = Api())
+			{
+				var reqJson = JsonConvert.SerializeObject(objToPut, Json.JsonSerializerSettings);
+				var reqContent = new StringContent(reqJson, System.Text.Encoding.UTF8, "application/json");
+				var response = await apiClient.PutAsync(url, reqContent);
+
+				if(response.IsSuccessStatusCode == false)
+				{
+					throw new Exception($"An error({response.StatusCode}) was encountered attempting to PUT Responsibilities to {url}");
+				}
+
+				// The Response is a Person object, use it to update our Person variable
+				var stringResult = await response.Content.ReadAsStringAsync();
+				result = JsonConvert.DeserializeObject<Person>(stringResult, Json.JsonSerializerSettings);
+			}
+			
+			// Everything updated, close the modal
+			Mf.Close();
+
+			// Invoking after close because the two-way binding can cause hiccups in the ModalForm.
+			await PersonChanged.InvokeAsync(result);
+			
+			// We've saved our changes reset the bools that dicate the ModalForms behavior.
+			ResetForm();
+		}
+		catch(Exception ex)
+		{
+			Ex = ex;
+		}
+		StateHasChanged();// Force it to redraw the component since the Expertise entries are drawn procedurally.
+	}
+
+	public void Dispose() { }
+}

--- a/src/Web/wwwroot/index.html
+++ b/src/Web/wwwroot/index.html
@@ -21,6 +21,7 @@
     
     <script src="_content/RivetBlazor/js/rivet-blazor.min.js"></script><!-- JS for RivetBlazor -->
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="/js/interop.js"></script>
 </body>
 
 </html>

--- a/src/Web/wwwroot/js/interop.js
+++ b/src/Web/wwwroot/js/interop.js
@@ -1,0 +1,27 @@
+var modalsConfirmBeforeClose = []
+
+function removeModalConfirmBeforeClose(modalId){
+	var pos = -1;
+	do {
+		pos = modalsConfirmBeforeClose.indexOf(modalId);
+		if(pos > -1){
+			modalsConfirmBeforeClose.splice(pos, 1);
+		}
+	} while(pos > -1);
+}
+
+// Listen for a custom "modalClose" event
+document.addEventListener('modalClose', event => {
+	var modalId = event.detail.name();
+	
+	for(let confId of modalsConfirmBeforeClose){
+		if(confId == modalId){
+			// This is a modal we want to confirm before closing.
+			if(confirm("There may be unsaved changes in this form. Are you sure you want to close it?") == false){
+				// They did not mean to close it, re-open the modal.
+				Modal.open(event.detail.name());
+			}
+			break;
+		}
+	}
+}, false);


### PR DESCRIPTION
Adds components with two-way binding on the Person parameter for modifying `Person.Expertise` and `Person.Responsibilities`.

Adds a parameter, `ConfirmBeforeClose`, to `ModalForm` that lets us use JS Interop to prevent closing a modal when the form has been changed.

When fetching suggestions for Expertise from Stack Exchange it makes a cancellable request to reduce extra calls while the user is still typing.