### PR TITLE
People Location Changes

### DIFF
--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -168,6 +168,10 @@
 				{
 					values.Add((T)enums);
 				}
+				else
+				{
+					GeneralException = new Exception($"{TValue} is not a valid {key}");
+				}
 			}
 		}
 	}

--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -75,7 +75,7 @@
 							</div>
 						}
 					}
-					else if (IsMatchFound)
+					else if (ShowNoResultsMessage)
 					{
 						<div class="rvt-panel"><p>No people found matching those filters. You can make yourself easier to find by <a href="/people/@LoggedInUser.Username">keeping your profile up to date.</a></p></div>
 					}
@@ -95,7 +95,7 @@
 	private AuthenticatedUser LoggedInUser;
 	private Person Person = new Person();
 	private List<Person> peopleList = new List<Person>();
-	private bool IsMatchFound;
+	private bool ShowNoResultsMessage;
 	private bool inline = false;
 	private HttpClient Api() => ClientFactory.CreateClient("Api");
 	private string finalCheckedValues;
@@ -138,6 +138,7 @@
 				using (Loading())
 				{
 					peopleList.Clear();
+					ShowNoResultsMessage = false;
 
 					queryParams = await GetQueryParams();
 					
@@ -145,10 +146,7 @@
 					if(queryParams.Count > 0 || FetchRootLevel)
 					{
 						await GetPeople();
-						if (peopleList.Count() != 0)
-						{
-							IsMatchFound = true;
-						}
+						
 						FetchRootLevel = false;// Disallow fetching /people from the API
 					}
 				}
@@ -245,16 +243,10 @@
 
 	private async Task GetPeople()
 	{
-		if (Roles.Count() == 0 && Responsibilities.Count() == 0 && Campuses.Count() == 0 && Areas.Count() == 0)
-		{
-			peopleList = await GetWithErrorHandling<List<Person>>("/people");
-		}
-		else
-		{
-			queryParams = await GetQueryParams();
-			RequestUri = QueryHelpers.AddQueryString("/people", queryParams);
-			peopleList = await GetWithErrorHandling<List<Person>>(RequestUri);
-		}
+		queryParams = await GetQueryParams();
+		RequestUri = QueryHelpers.AddQueryString("/people", queryParams);
+		peopleList = await GetWithErrorHandling<List<Person>>(RequestUri);
+		ShowNoResultsMessage = peopleList.Count == 0;
 	}
 
 	private async Task ExportResultsToCSV()

--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -124,6 +124,7 @@
 
 	private void LocationChanged(object sender, LocationChangedEventArgs e)
 	{
+		GeneralException = null;
 		base.InvokeAsync(async () => {
 			var query = new Uri(Navigation.Uri).Query;
 			var queryDict = HttpUtility.ParseQueryString(query);
@@ -180,7 +181,6 @@
 	{
 		queryParams = await GetQueryParams();
 		FetchRootLevel = true;// Allow fetching /people from the API
-		GeneralException = null;
 
 		var destination = QueryHelpers.AddQueryString("/people", queryParams);
 		// Navigate to destination, which will make LocationChanged() fire.

--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -170,7 +170,7 @@
 				}
 				else
 				{
-					GeneralException = new Exception($"{TValue} is not a valid {key}");
+					GeneralException = new Exception($"'{TValue}' is not a valid '{key}'");
 				}
 			}
 		}
@@ -180,9 +180,9 @@
 	{
 		queryParams = await GetQueryParams();
 		FetchRootLevel = true;// Allow fetching /people from the API
+		GeneralException = null;
 
 		var destination = QueryHelpers.AddQueryString("/people", queryParams);
-		Console.WriteLine($"We're off to {destination}");
 		// Navigate to destination, which will make LocationChanged() fire.
 		Navigation.NavigateTo(destination);
 	}

--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -82,7 +82,7 @@
 				</div>
 			</div>
 				<p>
-					<button id="apply-filter" class="rvt-button" type="submit" @onclick=@GetFilteredPeople>Apply Filters</button>
+					<button id="apply-filter" class="rvt-button" type="submit" @onclick=@UpdateQueryString>Apply Filters</button>
 				</p>
 
 		</Authenticated>
@@ -116,61 +116,64 @@
 		editContext = new EditContext(Responsibilities);
 
 		LoggedInUser = await sessionStorage.GetItemAsync<AuthenticatedUser>("user");
+		
+		Navigation.LocationChanged += LocationChanged;
+		LocationChanged(null, null);
+	}
 
-		var query = new Uri(Navigation.Uri).Query;
-		var queryDict = HttpUtility.ParseQueryString(query);
-		if (!string.IsNullOrWhiteSpace(queryDict.ToString()) && !string.IsNullOrWhiteSpace(queryParams.ToString()))
-		{
-			if (queryDict.Get("role") != null) await ConvertNameValueToEnum<Role>(queryDict, Roles, "role");
-			if (queryDict.Get("campus") != null) await ConvertNameValueToEnum<Campus>(queryDict, Campuses, "campus");
-			if (queryDict.Get("area") != null) await ConvertNameValueToEnum<Area>(queryDict, Areas, "area");
-			if (queryDict.Get("class") != null) await ConvertNameValueToEnum<Responsibilities>(queryDict, Responsibilities,	"class");
-
+	private void LocationChanged(object sender, LocationChangedEventArgs e)
+	{
+		base.InvokeAsync(async () => {
+			var query = new Uri(Navigation.Uri).Query;
+			var queryDict = HttpUtility.ParseQueryString(query);
+			
+			await ConvertNameValueToEnum<Role>(queryDict, Roles, "role");
+			await ConvertNameValueToEnum<Campus>(queryDict, Campuses, "campus");
+			await ConvertNameValueToEnum<Area>(queryDict, Areas, "area");
+			await ConvertNameValueToEnum<Responsibilities>(queryDict, Responsibilities,	"class");
+			
 			if(LoggedInUser != null)
 			{
 				using (Loading())
 				{
 					queryParams = await GetQueryParams();
-					await GetFilteredPeople();
+					
+					await GetPeople();
+					if (peopleList.Count() != 0)
+					{
+						IsMatchFound = true;
+					}
 				}
 			}
-		}
-		RequestUri = null;
-		queryParams = new Dictionary<string, string>();
+			RequestUri = null;
+			queryParams = new Dictionary<string, string>();
+		});
 	}
 
 	private async Task ConvertNameValueToEnum<T>(NameValueCollection queryDict, List<T> values, string key)
 	{
-		foreach (var TValue in queryDict.Get(key).Split(',').Where(v => string.IsNullOrWhiteSpace(v) == false).Select(v => v.Trim()))
+		values.Clear();
+		if (queryDict.Get(key) != null)
 		{
-			var success = Enum.TryParse(typeof(T), TValue, out var enums);
-			if(success)
+			foreach (var TValue in queryDict.Get(key).Split(',').Where(v => string.IsNullOrWhiteSpace(v) == false).Select(v => v.Trim()))
 			{
-				values.Add((T)enums);
+				var success = Enum.TryParse(typeof(T), TValue, out var enums);
+				if(success)
+				{
+					values.Add((T)enums);
+				}
 			}
 		}
 	}
 
-	public async Task GetFilteredPeople()
+	public async Task UpdateQueryString()
 	{
-		await GetPeople();
-		if (peopleList.Count() != 0)
-		{
-			IsMatchFound = true;
-		}		
-
-		if (!string.IsNullOrEmpty(RequestUri))
-		{
-			// Update the browser's URI to match the RequestUri
-			Navigation.NavigateTo(RequestUri);
-		}
-		else
-		{
-			// Update the browser's URI to match the AbsolutePath
-			var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
-			Navigation.NavigateTo(uri.AbsolutePath);
-		}
-		RequestUri = null;
+		queryParams = await GetQueryParams();
+		var destination = QueryHelpers.AddQueryString("/people", queryParams);
+		Console.WriteLine($"We're off to {destination}");
+		
+		// Navigate to destination, which will make LocationChanged() fire.
+		Navigation.NavigateTo(destination);
 	}
 
 	private async Task<Dictionary<string, string>> GetQueryParams()
@@ -287,6 +290,9 @@
 		return result;
 	}
 
-	public void Dispose() { }
+	public void Dispose()
+	{
+		Navigation.LocationChanged -= LocationChanged;
+	}
 
 }

--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -94,7 +94,7 @@
 	private Exception GeneralException;
 	private AuthenticatedUser LoggedInUser;
 	private Person Person = new Person();
-	private IEnumerable<Person> peopleList = new List<Person>();
+	private List<Person> peopleList = new List<Person>();
 	private bool IsMatchFound;
 	private bool inline = false;
 	private HttpClient Api() => ClientFactory.CreateClient("Api");
@@ -105,6 +105,7 @@
 	private List<Area> Areas = new List<Area>();
 	private List<Responsibilities> Responsibilities = new List<Responsibilities>();
 	private bool ShowLoader = false;
+	private bool FetchRootLevel = false;
 	private IDisposable Loading() => new DisposableLoader(s => ShowLoader = s, StateHasChanged);
 	private string RequestUri;
 
@@ -136,12 +137,19 @@
 			{
 				using (Loading())
 				{
+					peopleList.Clear();
+
 					queryParams = await GetQueryParams();
 					
-					await GetPeople();
-					if (peopleList.Count() != 0)
+					// If we've just navigated to /people don't fetch records from the API
+					if(queryParams.Count > 0 || FetchRootLevel)
 					{
-						IsMatchFound = true;
+						await GetPeople();
+						if (peopleList.Count() != 0)
+						{
+							IsMatchFound = true;
+						}
+						FetchRootLevel = false;// Disallow fetching /people from the API
 					}
 				}
 			}
@@ -169,9 +177,10 @@
 	public async Task UpdateQueryString()
 	{
 		queryParams = await GetQueryParams();
+		FetchRootLevel = true;// Allow fetching /people from the API
+
 		var destination = QueryHelpers.AddQueryString("/people", queryParams);
 		Console.WriteLine($"We're off to {destination}");
-		
 		// Navigate to destination, which will make LocationChanged() fire.
 		Navigation.NavigateTo(destination);
 	}


### PR DESCRIPTION
Handle deep linking to filtered results, just browsing to `/people`, or looking at filtered results and browsing back to `/people`.

The heart of this change is using a `NavigationManager.LocationChanged()` event to kick off parsing the query parameters and submitting our request to the API.