### PR TITLE
SSSP Endpoint

### DIFF
--- a/src/API/Data/SupportRelationshipsRepository.cs
+++ b/src/API/Data/SupportRelationshipsRepository.cs
@@ -32,7 +32,11 @@ namespace API.Data
 		public static Task<Result<List<SsspSupportRelationshipResponse>, Error>> GetSssp()
 			=> ExecuteDbPipeline("Get all support relationships in SSSP format", async db =>
 			{
-				var result = await db.SupportRelationships
+				var result = new List<SsspSupportRelationshipResponse>();
+				// Get all the SupportRelationships that have a usable email
+				// That means both units that have an email
+				// or units that do not have an email, but have a Leader that has an email.
+				var supportRelationships = db.SupportRelationships
 					.Include(r => r.Department)
 					.Include(r => r.Unit)
 					.Include(r => r.Unit.UnitMembers).ThenInclude(r => r.Person)
@@ -40,22 +44,54 @@ namespace API.Data
 					.Where(r =>
 						string.IsNullOrWhiteSpace(r.Unit.Email) == false
 						|| r.Unit.UnitMembers.Any(um => um.Role == Role.Leader && string.IsNullOrWhiteSpace(um.Person.CampusEmail) == false))
-					.AsNoTracking()
+					.AsNoTracking();
+
+				// SupportRelationships with units that have an email can easily be transformed into a SsspSupportRelationshipResponse.
+				var unitsThatHaveEmail = supportRelationships
+					.Where(r => string.IsNullOrWhiteSpace(r.Unit.Email) == false)
 					.Select(sr => new SsspSupportRelationshipResponse { 
 						Key = 0, // We'll be providing unique keys later.
 						Dept = sr.Department.Name,
 						DeptDescription = sr.Department.Description,
+						ContactEmail = sr.Unit.Email
+					});
+				
+				/*
+					Units that don't have an email are harder to figure out because they can have more than one leader.
+					Get all those SupportRelationships and select the details we need to make
+					a SsspSupportRelationshipResponse: The department and the unit's leaders.
+					Then loop over the results, and make an entry for each of their leaders.
+				*/
+				var unitsMissingEmail = new List<SsspSupportRelationshipResponse>();
+				var SupportRelationshipsWithLeaders = supportRelationships
+					.Where(r => string.IsNullOrWhiteSpace(r.Unit.Email))
+					.Select(r => new { Department = r.Department, Leaders = r.Unit.UnitMembers.Where(um => um.Role == Role.Leader)});
+					
+				foreach(var relationship in SupportRelationshipsWithLeaders)
+				{
+					foreach(var leader in relationship.Leaders)
+					{
+						unitsMissingEmail.Add(new SsspSupportRelationshipResponse{
+							Key = 0, // We'll be providing unique keys later.
+							Dept = relationship.Department.Name,
+							DeptDescription = relationship.Department.Description,
+							ContactEmail = leader.Person.CampusEmail
+						});
+					}
+				}
+				
+				// Combine our results.
+				result.AddRange(unitsThatHaveEmail);
+				result.AddRange(unitsMissingEmail);
 
-						ContactEmail = 
-							string.IsNullOrWhiteSpace(sr.Unit.Email) == false
-								? sr.Unit.Email
-								: sr.Unit.UnitMembers.First(um => um.Role == Role.Leader && string.IsNullOrWhiteSpace(um.Person.CampusEmail) == false).Person.CampusEmail
-					})
+				// De-duplicate, sort and return result.
+				result = result
 					.Distinct() // Weed out duplicates
 					.OrderBy(r => r.Dept)
 					.ThenBy(r => r.ContactEmail)
-					.ToListAsync();
+					.ToList();
 
+				// SSSP doesn't need a proper unique Id for all the relationshps, they just need a row identifier.
 				var k = 1;
 				foreach(var item in result)
 				{

--- a/src/API/Data/SupportRelationshipsRepository.cs
+++ b/src/API/Data/SupportRelationshipsRepository.cs
@@ -51,7 +51,7 @@ namespace API.Data
 				// Massage them into SsspSupportRelationshipResponse
 				var result = supportRelationships
 					.SelectMany(sr => SsspSupportRelationshipResponse.FromSupportRelationship(sr))
-					.Distinct() // Weed out duplicates
+					.Distinct(new SsspSupportRelationshipResponse.Comparer()) // Weed out duplicates
 					.OrderBy(r => r.Dept)
 					.ThenBy(r => r.ContactEmail)
 					.ToList();

--- a/src/API/Functions/SupportRelationships.cs
+++ b/src/API/Functions/SupportRelationships.cs
@@ -114,5 +114,14 @@ namespace API.Functions
 				.Bind(_ => SupportRelationshipsRepository.DeleteSupportRelationship(req, relationshipId))
 				.Finally(result => Response.NoContent(req, result));
 		}
+
+		[FunctionName(nameof(SupportRelationships.SsspSupportRelationships))]
+		[OpenApiOperation(nameof(SupportRelationships.SsspSupportRelationships), SupportRelationshipsTitle, Summary = "Lists Support Relationships using a query specifically for SSSP's use.")]
+		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SsspSupportRelationshipResponse>), Description = "A collection of department support relationship records")]
+		public static Task<IActionResult> SsspSupportRelationships(
+			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "SsspSupportRelationships")] HttpRequest req)
+			=> Security.Authenticate(req)
+				.Bind(query => SupportRelationshipsRepository.GetSssp())
+				.Finally(results => Response.Ok(req, results));
 	}
 }

--- a/src/Models/DTO/SsspSupportRelationshipResponse.cs
+++ b/src/Models/DTO/SsspSupportRelationshipResponse.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Models
 {
 	public class SsspSupportRelationshipResponse
@@ -7,5 +10,40 @@ namespace Models
 		public string DeptDescription { get; set; }
 		public string ContactEmail { get; set; }
 
+		public static List<SsspSupportRelationshipResponse> FromSupportRelationship(SupportRelationship input)
+		{
+			var output = new List<SsspSupportRelationshipResponse>();
+			// SupportRelationships for Units that don't have an email set should use the emails of their leaders.
+			if(string.IsNullOrWhiteSpace(input.Unit.Email))
+			{
+				foreach(var leader in input.Unit.UnitMembers.Where(um => um.Role == Role.Leader && string.IsNullOrWhiteSpace(um.Person.CampusEmail) == false))
+				{
+					output.Add(
+						new SsspSupportRelationshipResponse
+						{
+							Key = 0,
+							Dept = input.Department.Name,
+							DeptDescription = input.Department.Description,
+							ContactEmail = leader.Person.CampusEmail
+						}
+					);
+				}
+			}
+			else
+			{
+				// If we have it just use the Unit.Email value.
+				output.Add(
+					new SsspSupportRelationshipResponse
+					{
+						Key = 0,
+						Dept = input.Department.Name,
+						DeptDescription = input.Department.Description,
+						ContactEmail = input.Unit.Email
+					}
+				);
+			}
+
+			return output;
+		}
 	}
 }

--- a/src/Models/DTO/SsspSupportRelationshipResponse.cs
+++ b/src/Models/DTO/SsspSupportRelationshipResponse.cs
@@ -1,11 +1,11 @@
 namespace Models
 {
 	public class SsspSupportRelationshipResponse
-    {
-        public int Key { get; set; }
-        public string Dept { get; set; }
-        public string DeptDescription { get; set; }
-        public string ContactEmail { get; set; }
+	{
+		public int Key { get; set; }
+		public string Dept { get; set; }
+		public string DeptDescription { get; set; }
+		public string ContactEmail { get; set; }
 
-    }
+	}
 }

--- a/src/Models/DTO/SsspSupportRelationshipResponse.cs
+++ b/src/Models/DTO/SsspSupportRelationshipResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -44,6 +45,29 @@ namespace Models
 			}
 
 			return output;
+		}
+
+		public class Comparer : IEqualityComparer<SsspSupportRelationshipResponse>
+		{
+			public bool Equals(SsspSupportRelationshipResponse x, SsspSupportRelationshipResponse y) =>
+				x.Dept == y.Dept && x.DeptDescription == y.DeptDescription && x.ContactEmail == y.ContactEmail
+					? true
+					: false;
+			
+
+			public int GetHashCode(SsspSupportRelationshipResponse obj)
+			{
+				//Check whether the object is null
+				if (Object.ReferenceEquals(obj, null)) return 0;
+
+				//Get hash code for all the properties we compare
+				int deptHash = obj.Dept.GetHashCode();
+				int descHash = obj.DeptDescription.GetHashCode();
+				int emailHash = obj.ContactEmail.GetHashCode();
+
+				//Calculate the hash code for the product.
+				return deptHash ^ descHash ^ emailHash;
+			}
 		}
 	}
 }

--- a/src/Models/DTO/SsspSupportRelationshipResponse.cs
+++ b/src/Models/DTO/SsspSupportRelationshipResponse.cs
@@ -1,0 +1,11 @@
+namespace Models
+{
+	public class SsspSupportRelationshipResponse
+    {
+        public int Key { get; set; }
+        public string Dept { get; set; }
+        public string DeptDescription { get; set; }
+        public string ContactEmail { get; set; }
+
+    }
+}

--- a/src/Models/Entities/SupportRelationship.cs
+++ b/src/Models/Entities/SupportRelationship.cs
@@ -20,6 +20,14 @@ namespace Models
 
         /// The support type in this relationship
         public SupportType SupportType { get; set; }
+
+        public SupportRelationship() {}
+        public SupportRelationship(int unitId, int departmentId, int? supportTypeId)
+        {
+            UnitId = unitId;
+            DepartmentId = departmentId;
+            SupportTypeId = supportTypeId;
+        }
     }
 
 }

--- a/tests/API/Integration/SupportRelationshipsTests.cs
+++ b/tests/API/Integration/SupportRelationshipsTests.cs
@@ -324,37 +324,29 @@ namespace Integration
 				await db.SaveChangesAsync();
 			}
 
-			private static readonly object[] _sourceLists = 
+			private static IEnumerable<TestCaseData> _Cases
 			{
-				/* Department has single support relationship */
-				// Supporting unit has an email
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null) }, 1},
-				// Supporting unit has no email but ONE leader who does
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null) }, 1},
-				// Supporting unit has no email, but SEVERAL leaders who do
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeadersWhoDoId, ParksDeptId, null) }, 2},
-				// Supporting unit has no email, and no leader with an email
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 0},
-				// Supporting unit has an email but is no longer active.
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 0},
+				get
+				{
+					/* Department has single support relationship */
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null) }, 1, "Supporting unit has an email");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null) }, 1, "Supporting unit has no email but ONE leader who does");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeadersWhoDoId, ParksDeptId, null) }, 2, "Supporting unit has no email, but SEVERAL leaders who do");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 0, "Supporting unit has no email, and no leader with an email");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 0, "Supporting unit has an email but is no longer active.");
 
-				/* Department has multiple support relationships*/
-				// Both units have an email
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(SecondUnitWithEmailId, ParksDeptId, null) }, 2},
-				// One unit has an email, the other does not, but has a leader that does
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null) }, 2},
-				// One unit has no email but a leader that does, and the other has no email and no leaders
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 1},
-				// One unit has an email, the other unit is not active
-				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 1},
-				// Supported by two units each having the same email address, one getting its email from its unit the other from its unit's leader.
-				new object[] { new List<SupportRelationship> { new SupportRelationship(DuplicateAId, ParksDeptId, null), new SupportRelationship(DuplicateBId, ParksDeptId, null) }, 1},
-			};
-			
+					/* Department has multiple support relationships*/
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(SecondUnitWithEmailId, ParksDeptId, null) }, 2, "Both units have an email");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null) }, 2, "One unit has an email, the other does not, but has a leader that does");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 1, "One unit has no email but a leader that does, and the other has no email and no leaders");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 1, "One unit has an email, the other unit is not active");
+					yield return new TestCaseData(new List<SupportRelationship> { new SupportRelationship(DuplicateAId, ParksDeptId, null), new SupportRelationship(DuplicateBId, ParksDeptId, null) }, 1, "Supported by two units each having the same email address, one getting its email from its unit the other from its unit's leader.");
+				}
+			}
 
 			[Test]
-			[TestCaseSource("_sourceLists")]
-			public async Task SupportRelationshipsGetSsspFormat(IEnumerable<SupportRelationship> relationships, int expectedMatches)
+			[TestCaseSource(nameof(_Cases))]
+			public async Task SupportRelationshipsGetSsspFormat(IEnumerable<SupportRelationship> relationships, int expectedMatches, string description)
 			{
 				await Setup();
 				var db = GetDb();

--- a/tests/API/Integration/SupportRelationshipsTests.cs
+++ b/tests/API/Integration/SupportRelationshipsTests.cs
@@ -273,6 +273,8 @@ namespace Integration
 			private static int UnitWithNoEmailButLeadersWhoDoId = 4;
 			private static int UnitWithNoEmailAndNoLeaderWhoDoesId  = 5;
 			private static int UnitWithEmailInactiveId = 6;
+			private static int DuplicateAId = 7;
+			private static int DuplicateBId = 8;
 			private static int ParksDeptId = TestEntities.Departments.ParksId;
 			
 			private async Task Setup()
@@ -314,7 +316,11 @@ namespace Integration
 
 				var unitWithEmailInactive = new Unit { Id = UnitWithEmailInactiveId, Name = "Inactive Unit With Email", Description = "", Url = "", Email = "inactive@fake.com", UnitMembers = new List<UnitMember>(), Active = false };
 
-				db.Units.AddRange(new List<Unit> { unitWithEmail, secondUnitWithEmail, unitWithNoEmailButLeaderWhoDoes, unitWithNoEmailButLeadersWhoDo, unitWithNoEmailAndNoLeaderWhoDoes, unitWithEmailInactive });
+				var duplicateEmailUnitA = new Unit { Id = DuplicateAId, Name = "Duplicate A", Description = "", Url = "", Email = personWithEmail.CampusEmail, UnitMembers = new List<UnitMember>(), Active = true };
+				var duplicateEmailUnitB = new Unit { Id = DuplicateBId, Name = "Duplicate B", Description = "", Url = "", Email = null, UnitMembers = new List<UnitMember>(), Active = true };
+				duplicateEmailUnitB.UnitMembers.Add(new UnitMember { Person = personWithEmail, Role = Role.Leader, Permissions = UnitPermissions.ManageMembers, Notes = "" });
+
+				db.Units.AddRange(new List<Unit> { unitWithEmail, secondUnitWithEmail, unitWithNoEmailButLeaderWhoDoes, unitWithNoEmailButLeadersWhoDo, unitWithNoEmailAndNoLeaderWhoDoes, unitWithEmailInactive, duplicateEmailUnitA, duplicateEmailUnitB });
 				await db.SaveChangesAsync();
 			}
 
@@ -341,7 +347,8 @@ namespace Integration
 				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 1},
 				// One unit has an email, the other unit is not active
 				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 1},
-
+				// Supported by two units each having the same email address, one getting its email from its unit the other from its unit's leader.
+				new object[] { new List<SupportRelationship> { new SupportRelationship(DuplicateAId, ParksDeptId, null), new SupportRelationship(DuplicateBId, ParksDeptId, null) }, 1},
 			};
 			
 

--- a/tests/API/Integration/SupportRelationshipsTests.cs
+++ b/tests/API/Integration/SupportRelationshipsTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Models;
 using NUnit.Framework;
 
@@ -21,30 +23,8 @@ namespace Integration
 				var actual = await resp.Content.ReadAsAsync<List<SupportRelationshipResponse>>();
 				Assert.AreEqual(2, actual.Count);
 			}
-
-			[Test]
-			public async Task SupportRelationshipsGetSsspFormat()
-			{
-				/* Department has single support relationship */
-				// Supporting unit has an email
-				// Supporting unit has no email but ONE leader who does
-				// Supporting unit has no email, but SEVERAL leaders who do
-				// Supporting unit has no email, and no leader with an email
-				// Supporting unit has an email but is no longer active.
-
-				/* Department has multiple support relationships*/
-				// Both units have an email
-				// One unit has an email, the other does not, but has a leader that does
-				// One unit has no email but a leader that does, and the other has no email and no leaders
-				// One unit has an email, the other unit is not active
-
-				var resp = await GetAuthenticated("SsspSupportRelationships");
-				AssertStatusCode(resp, HttpStatusCode.OK);
-				var actual = await resp.Content.ReadAsAsync<List<SsspSupportRelationshipResponse>>();
-				Assert.AreEqual(2, actual.Count);
-				Assert.False(true, "Still writing test.");
-			}
 		}
+
 		public class GetOne : ApiTest
 		{
 			[TestCase(TestEntities.SupportRelationships.ParksAndRecRelationshipId, HttpStatusCode.OK)]
@@ -281,6 +261,111 @@ namespace Integration
 			{
 				var resp = await DeleteAuthenticated($"supportRelationships/{relationshipId}", jwt);
 				AssertStatusCode(resp, expectedCode);
+			}
+		}
+
+		public class SsspTests : ApiTest
+		{
+			private Database.PeopleContext GetDb() => Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
+			private static int UnitWithEmailId = 1;
+			private static int SecondUnitWithEmailId = 2;
+			private static int UnitWithNoEmailButLeaderWhoDoesId = 3;
+			private static int UnitWithNoEmailButLeadersWhoDoId = 4;
+			private static int UnitWithNoEmailAndNoLeaderWhoDoesId  = 5;
+			private static int UnitWithEmailInactiveId = 6;
+			private static int ParksDeptId = TestEntities.Departments.ParksId;
+			
+			private async Task Setup()
+			{
+				var db = GetDb();
+				// Nuke existing Support Relationships and Units
+				db.Database.ExecuteSqlRaw(@"
+					TRUNCATE 
+						public.building_relationships, 
+						public.people, 
+						public.support_relationships, 
+						public.units,
+						public.unit_members,
+						public.unit_member_tools
+					RESTART IDENTITY
+					CASCADE;
+				");
+
+				var personWithEmail = new Person { Netid = "hasemail", Name="Email, Has", Position = "Middle Manager", Location="Poplars", Campus = "BL", Notes = "", PhotoUrl = "", CampusPhone = "55555", CampusEmail = "hasemail@iu.edu" };
+				var anotherPersonWithEmail = new Person { Netid = "otherperson", Name="Email, Has Also", Position = "Lower Manager", Location="Ball hall", Campus = "IN", Notes = "", PhotoUrl = "", CampusPhone = "55557", CampusEmail = "otherperson@iupui.edu" };
+				var personWithoutEmail = new Person { Netid = "noemail", Name="Email, Has Not", Position = "AVP", Location="Poplars", Campus = "BL", Notes = "", PhotoUrl = "", CampusPhone = "55556", CampusEmail = "" };
+
+				db.People.AddRange(new List<Person> {personWithEmail, anotherPersonWithEmail, personWithoutEmail});
+				await db.SaveChangesAsync();
+
+				var unitWithEmail = new Unit { Id = UnitWithEmailId, Name = "Unit With Email", Description = "", Url = "", Email = "unit@fake.com", UnitMembers = new List<UnitMember>(), Active = true };
+				var secondUnitWithEmail = new Unit { Id = SecondUnitWithEmailId, Name = "Another Unit With Email", Description = "", Url = "", Email = $"unit{SecondUnitWithEmailId}@fake.com", UnitMembers = new List<UnitMember>(), Active = true };
+				
+				var unitWithNoEmailButLeaderWhoDoes = new Unit { Id = UnitWithNoEmailButLeaderWhoDoesId, Name = "Unit Without Email, But Leader Does", Description = "", Url = "", Email = null, UnitMembers = new List<UnitMember>(), Active = true };
+				unitWithNoEmailButLeaderWhoDoes.UnitMembers.Add(new UnitMember { Person = personWithEmail, Role = Role.Leader, Permissions = UnitPermissions.ManageMembers, Notes = "" });
+				
+				var unitWithNoEmailButLeadersWhoDo = new Unit { Id = UnitWithNoEmailButLeadersWhoDoId, Name = "Unit Without Email, But LeaderS Do", Description = "", Url = "", Email = null, UnitMembers = new List<UnitMember>(), Active = true };
+				unitWithNoEmailButLeadersWhoDo.UnitMembers.Add(new UnitMember { Person = personWithEmail, Role = Role.Leader, Permissions = UnitPermissions.ManageMembers, Notes = "" });
+				unitWithNoEmailButLeadersWhoDo.UnitMembers.Add(new UnitMember { Person = anotherPersonWithEmail, Role = Role.Leader, Permissions = UnitPermissions.ManageTools, Notes = "" });
+				
+				var unitWithNoEmailAndNoLeaderWhoDoes = new Unit { Id = UnitWithNoEmailAndNoLeaderWhoDoesId, Name = "Unit Without Email, And The Leader doesn't either", Description = "", Url = "", Email = null, UnitMembers = new List<UnitMember>(), Active = true };
+				unitWithNoEmailAndNoLeaderWhoDoes.UnitMembers.Add(new UnitMember { Person = personWithoutEmail, Role = Role.Leader, Permissions = UnitPermissions.ManageMembers, Notes = "" });
+
+				var unitWithEmailInactive = new Unit { Id = UnitWithEmailInactiveId, Name = "Inactive Unit With Email", Description = "", Url = "", Email = "inactive@fake.com", UnitMembers = new List<UnitMember>(), Active = false };
+
+				db.Units.AddRange(new List<Unit> { unitWithEmail, secondUnitWithEmail, unitWithNoEmailButLeaderWhoDoes, unitWithNoEmailButLeadersWhoDo, unitWithNoEmailAndNoLeaderWhoDoes, unitWithEmailInactive });
+				await db.SaveChangesAsync();
+			}
+
+			private static readonly object[] _sourceLists = 
+			{
+				/* Department has single support relationship */
+				// Supporting unit has an email
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null) }, 1},
+				// Supporting unit has no email but ONE leader who does
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null) }, 1},
+				// Supporting unit has no email, but SEVERAL leaders who do
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeadersWhoDoId, ParksDeptId, null) }, 2},
+				// Supporting unit has no email, and no leader with an email
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 0},
+				// Supporting unit has an email but is no longer active.
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 0},
+
+				/* Department has multiple support relationships*/
+				// Both units have an email
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(SecondUnitWithEmailId, ParksDeptId, null) }, 2},
+				// One unit has an email, the other does not, but has a leader that does
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null) }, 2},
+				// One unit has no email but a leader that does, and the other has no email and no leaders
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithNoEmailButLeaderWhoDoesId, ParksDeptId, null), new SupportRelationship(UnitWithNoEmailAndNoLeaderWhoDoesId, ParksDeptId, null) }, 1},
+				// One unit has an email, the other unit is not active
+				new object[] { new List<SupportRelationship> { new SupportRelationship(UnitWithEmailId, ParksDeptId, null), new SupportRelationship(UnitWithEmailInactiveId, ParksDeptId, null) }, 1},
+
+			};
+			
+
+			[Test]
+			[TestCaseSource("_sourceLists")]
+			public async Task SupportRelationshipsGetSsspFormat(IEnumerable<SupportRelationship> relationships, int expectedMatches)
+			{
+				await Setup();
+				var db = GetDb();
+				// Insert the provided relationships
+				db.SupportRelationships.AddRange(relationships);
+				await db.SaveChangesAsync();
+
+				// Get the listing from the API
+				var resp = await GetAuthenticated("SsspSupportRelationships");
+				AssertStatusCode(resp, HttpStatusCode.OK);
+				var actual = await resp.Content.ReadAsAsync<List<SsspSupportRelationshipResponse>>();
+				// Ensure all results are valid.
+				Assert.False(actual.Any(sr => string.IsNullOrWhiteSpace(sr.ContactEmail)));
+				Assert.False(actual.Any(sr => string.IsNullOrWhiteSpace(sr.Dept)));
+				Assert.False(actual.Any(sr => string.IsNullOrWhiteSpace(sr.DeptDescription)));
+				Assert.False(actual.Any(sr => sr.Key <= 0));
+
+				// Ensure we got the expected number of results.
+				Assert.AreEqual(expectedMatches, actual.Count);
 			}
 		}
 	}

--- a/tests/API/Integration/SupportRelationshipsTests.cs
+++ b/tests/API/Integration/SupportRelationshipsTests.cs
@@ -21,6 +21,29 @@ namespace Integration
 				var actual = await resp.Content.ReadAsAsync<List<SupportRelationshipResponse>>();
 				Assert.AreEqual(2, actual.Count);
 			}
+
+			[Test]
+			public async Task SupportRelationshipsGetSsspFormat()
+			{
+				/* Department has single support relationship */
+				// Supporting unit has an email
+				// Supporting unit has no email but ONE leader who does
+				// Supporting unit has no email, but SEVERAL leaders who do
+				// Supporting unit has no email, and no leader with an email
+				// Supporting unit has an email but is no longer active.
+
+				/* Department has multiple support relationships*/
+				// Both units have an email
+				// One unit has an email, the other does not, but has a leader that does
+				// One unit has no email but a leader that does, and the other has no email and no leaders
+				// One unit has an email, the other unit is not active
+
+				var resp = await GetAuthenticated("SsspSupportRelationships");
+				AssertStatusCode(resp, HttpStatusCode.OK);
+				var actual = await resp.Content.ReadAsAsync<List<SsspSupportRelationshipResponse>>();
+				Assert.AreEqual(2, actual.Count);
+				Assert.False(true, "Still writing test.");
+			}
 		}
 		public class GetOne : ApiTest
 		{

--- a/tests/API/Integration/SupportRelationshipsTests.cs
+++ b/tests/API/Integration/SupportRelationshipsTests.cs
@@ -310,6 +310,7 @@ namespace Integration
 				
 				var unitWithNoEmailAndNoLeaderWhoDoes = new Unit { Id = UnitWithNoEmailAndNoLeaderWhoDoesId, Name = "Unit Without Email, And The Leader doesn't either", Description = "", Url = "", Email = null, UnitMembers = new List<UnitMember>(), Active = true };
 				unitWithNoEmailAndNoLeaderWhoDoes.UnitMembers.Add(new UnitMember { Person = personWithoutEmail, Role = Role.Leader, Permissions = UnitPermissions.ManageMembers, Notes = "" });
+				unitWithNoEmailAndNoLeaderWhoDoes.UnitMembers.Add(new UnitMember { Person = personWithEmail, Role = Role.Member, Permissions = UnitPermissions.ManageMembers, Notes = "" });
 
 				var unitWithEmailInactive = new Unit { Id = UnitWithEmailInactiveId, Name = "Inactive Unit With Email", Description = "", Url = "", Email = "inactive@fake.com", UnitMembers = new List<UnitMember>(), Active = false };
 


### PR DESCRIPTION
Adds a `/SsspSupportRelationships` endpoint to the API.

This generates a list of all the SupportRelationshp with email information, gotten either by the `Unit.Email` value or by getting the emails for the Leaders of a unit that does not have an email set.

Corey Tarbell has been generating this data with a query that can be simplified to
```pgsql
SELECT DISTINCT d.name AS dept, d.description AS dept_desc,
	CASE
		WHEN u.email IS NULL THEN p.campus_email
		WHEN TRIM(u.email) = '' THEN p.campus_email
		ELSE u.email
	END AS contact_email
FROM support_relationships sr
INNER JOIN departments d ON d.id = sr.department_id
INNER JOIN units u
	ON u.id = sr.unit_id
	AND u.active
LEFT OUTER JOIN unit_members um
	ON um.unit_id = u.id
	AND um.role = 4 --Leaders only
LEFT OUTER JOIN people p ON p.id = um.person_id
WHERE (u.email IS NOT NULL AND TRIM(u.email) <> '')
OR (p.campus_email IS NOT NULL AND TRIM(p.campus_email) <> '')
ORDER BY dept ASC, contact_email ASC
```
In this branch I attempt to recreate that using Linq, and with the test data we have available I think I've done it.

Please let me know if I missed any test cases in `SupportRelationshipTests`.

Included for future reference here is Corey's raw query.
[sssp-query.txt](https://github.com/indiana-university/itpeople-functions-v2/files/7548426/sssp-query.txt)
