### PR TITLE
Unit archive delete permissions

### DIFF
--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -44,7 +44,7 @@ namespace API.Functions
         public static Task<IActionResult> UnitsGetOne(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}")] HttpRequest req, int unitId)
             => Security.Authenticate(req)
-                .Bind(requestor => AuthorizationRepository.DetermineUnitPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
+                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner, PermsGroups.GetPut))// Set headers saying what the requestor can do to this unit
                 .Bind(_ => UnitsRepository.GetOne(unitId))
                 .Finally(result => Response.Ok(req, result));
 

--- a/src/Web/Pages/Units/Unit.razor
+++ b/src/Web/Pages/Units/Unit.razor
@@ -63,7 +63,7 @@
 										<rvt-icon name="pencil"></rvt-icon>
 									</a>
 								}
-								@if (CanEditUnitDetails)
+								@if (CanDeleteUnit)
 								{
 									@if (CurrentUnit.Active)
 									{
@@ -440,6 +440,7 @@
 	private UnitResponse ChildUnitToAdd = new UnitResponse();
 	private bool UnitFormInvalid = false;
 	private bool CanEditUnitDetails = false;
+	private bool CanDeleteUnit = false;
 	private bool CanEditMemberTools = false;
 	private bool CanEditUnitMembers = false;
 	private bool CanEditSupportRelationships = false;
@@ -635,7 +636,8 @@
 	{
 		var response = await Get<UnitResponse>($"/Units/{UnitId}");
 		CurrentUnit = response.Value;
-		CanEditUnitDetails = response.Permissions.HasFlag(EntityPermissions.Post); //This is effectively binary and the other permissions (Put,Delete) mean the same as Post.
+		CanEditUnitDetails = response.Permissions.HasFlag(EntityPermissions.Put); //This is effectively binary and the other permissions (Put,Delete) mean the same as Post.
+		CanDeleteUnit = response.Permissions.HasFlag(EntityPermissions.Delete); //This is effectively binary and the other permissions (Put,Delete) mean the same as Post.
 	}
 
 	private async Task GetUnitChildren()


### PR DESCRIPTION
For the test unit he is in the role of owner, he can still see the icons to archive and delete the unit even though he doesn’t have permission. Are those icons only supposed to appear for superadmins?

As Owner:
![image](https://user-images.githubusercontent.com/2359966/149405862-32e83275-9bb5-46a2-97a7-70b8019e049e.png)

As Member:
![image](https://user-images.githubusercontent.com/2359966/149405906-05a293ce-8b9d-464c-bcf1-1a556350d611.png)

As Service Admin:
![image](https://user-images.githubusercontent.com/2359966/149405960-b65dffb1-b8ac-403f-958c-c3a206f3ed0c.png)
