### PR TITLE
Department GetAll limit

### DIFF
--- a/src/API/Functions/Departments.cs
+++ b/src/API/Functions/Departments.cs
@@ -23,6 +23,7 @@ namespace API.Functions
 		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<Department>), Description = "A collection of department records")]
 		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
 		[OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by department name/description, ex: 'Parks' or 'PA-PARK'")]
+		[OpenApiParameter("limit", In = ParameterLocation.Query, Description = "Restrict the number of responses to no more than this integer. ex: `15` or `20`.  `0` or less will return all records.")]
 		public static Task<IActionResult> DepartmentsGetAll(
 			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments")] HttpRequest req)
 			=> Security.Authenticate(req)

--- a/src/API/Functions/Departments.cs
+++ b/src/API/Functions/Departments.cs
@@ -23,7 +23,7 @@ namespace API.Functions
 		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<Department>), Description = "A collection of department records")]
 		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
 		[OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by department name/description, ex: 'Parks' or 'PA-PARK'")]
-		[OpenApiParameter("limit", In = ParameterLocation.Query, Description = "Restrict the number of responses to no more than this integer. ex: `15` or `20`.  `0` or less will return all records.")]
+		[OpenApiParameter("_limit", In = ParameterLocation.Query, Description = "Restrict the number of responses to no more than this integer. ex: `15` or `20`.  `0` or less will return all records.")]
 		public static Task<IActionResult> DepartmentsGetAll(
 			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments")] HttpRequest req)
 			=> Security.Authenticate(req)

--- a/src/API/Functions/PeopleSearchParameters.cs
+++ b/src/API/Functions/PeopleSearchParameters.cs
@@ -81,9 +81,9 @@ namespace API.Functions
             var queryParms = req.GetQueryParameterDictionary();
             queryParms.TryGetValue("q", out string q);
             
-            queryParms.TryGetValue("limit", out string limitString);
+            queryParms.TryGetValue("_limit", out string limitString);
             int.TryParse(limitString, out int limit);
-            
+
             return Pipeline.Success(new DepartmentSearchParameters(q, limit));
         }
     }

--- a/src/API/Functions/PeopleSearchParameters.cs
+++ b/src/API/Functions/PeopleSearchParameters.cs
@@ -69,14 +69,22 @@ namespace API.Functions
 
     public class DepartmentSearchParameters : BaseSearchParameters
     {
-        public DepartmentSearchParameters(string q) : base(q)
-        {}
+        public int Limit { get; }
+
+        public DepartmentSearchParameters(string q, int limit = 0) : base(q)
+        {
+            Limit = limit;
+        }
 
         public static Result<DepartmentSearchParameters, Error> Parse(HttpRequest req) 
         {
             var queryParms = req.GetQueryParameterDictionary();
             queryParms.TryGetValue("q", out string q);
-            return Pipeline.Success(new DepartmentSearchParameters(q));
+            
+            queryParms.TryGetValue("limit", out string limitString);
+            int.TryParse(limitString, out int limit);
+            
+            return Pipeline.Success(new DepartmentSearchParameters(q, limit));
         }
     }
 

--- a/src/Web/Pages/Search.razor
+++ b/src/Web/Pages/Search.razor
@@ -147,7 +147,7 @@
 
 	private async Task SearchUnits() => Units = (await Get<List<UnitResponse>>($"/Units?q={HttpUtility.UrlEncode(Q)}")).Value;
 	private async Task SearchPeople() => People = (await Get<List<Person>>($"/People?q={HttpUtility.UrlEncode(Q)}")).Value;
-	private async Task SearchDepartments() => Departments = (await Get<List<Department>>($"/Departments?q={HttpUtility.UrlEncode(Q)}")).Value;
+	private async Task SearchDepartments() => Departments = (await Get<List<Department>>($"/Departments?q={HttpUtility.UrlEncode(Q)}&_limit=25")).Value;
 	private async Task SearchBuildings() => Buildings = (await Get<List<Building>>($"/Buildings?q={HttpUtility.UrlEncode(Q)}")).Value;
 
 	public void Dispose(){

--- a/tests/API/Integration/DepartmentsTests.cs
+++ b/tests/API/Integration/DepartmentsTests.cs
@@ -54,6 +54,18 @@ namespace Integration
 				var actual = await resp.Content.ReadAsAsync<List<Department>>();
 				Assert.AreEqual(0, actual.Count);
 			}
+
+			[TestCase("0", 3)]
+			[TestCase("2", 2)]
+			[TestCase("-1", 3)]
+			[TestCase("twenty-five", 3)]
+			public async Task KnowYourLimitations(string limit, int expectedRecords)
+			{
+				var resp = await GetAuthenticated($"Departments?limit={limit}");
+				AssertStatusCode(resp, HttpStatusCode.OK);
+				var actual = await resp.Content.ReadAsAsync<List<Department>>();
+				Assert.AreEqual(expectedRecords, actual.Count);
+			}
 		}
 		public class GetOne : ApiTest
 		{

--- a/tests/API/Integration/DepartmentsTests.cs
+++ b/tests/API/Integration/DepartmentsTests.cs
@@ -61,7 +61,7 @@ namespace Integration
 			[TestCase("twenty-five", 3)]
 			public async Task KnowYourLimitations(string limit, int expectedRecords)
 			{
-				var resp = await GetAuthenticated($"Departments?limit={limit}");
+				var resp = await GetAuthenticated($"Departments?_limit={limit}");
 				AssertStatusCode(resp, HttpStatusCode.OK);
 				var actual = await resp.Content.ReadAsAsync<List<Department>>();
 				Assert.AreEqual(expectedRecords, actual.Count);


### PR DESCRIPTION
`DepartmentsRepository.GetAll()` had a hard-coded limit of returning 25 results.

This changes the behavior to default to returning all results, but adding a `_limit` query parameter to constrain the number of results returned.

I've updated all the requests in the web app to use `_limit` where it used to expect to always get a max of 25 records. (Interestingly the department suggestions when establishing a SupportRelationship for a unit was already trying to use `_limit`, but now it actually works 😜