### PR TITLE
Inherit permissions

### DIFF
--- a/src/API/Data/AuthorizationRepository.cs
+++ b/src/API/Data/AuthorizationRepository.cs
@@ -99,7 +99,11 @@ namespace API.Data
                 FetchPersonAndMembership(db, requestorNetId, unitId)
                 .Bind(person => ResolveUnitManagmentPermissions(person, unitId, new List<UnitPermissions> {permissions}, db, permissionsToGive))
                 .Tap(perms => req.SetEntityPermissions(perms)));
-
+internal static Task<Result<EntityPermissions, Error>> DetermineUnitManagementPermissions(HttpRequest req, string requestorNetId, int unitId, List<UnitPermissions> permissions, EntityPermissions permissionsToGive = PermsGroups.All)
+            => ExecuteDbPipeline($"resolve unit {unitId} and unit member management permissions", db =>
+                FetchPersonAndMembership(db, requestorNetId, unitId)
+                .Bind(person => ResolveUnitManagmentPermissions(person, unitId, permissions, db, permissionsToGive))
+                .Tap(perms => req.SetEntityPermissions(perms)));
         internal static Task<Result<EntityPermissions, Error>> DetermineUnitMemberToolPermissions(HttpRequest req, string requestorNetId, int membershipId)
             => ExecuteDbPipeline($"resolve unit {membershipId} member management permissions", db =>
                 FetchPersonAndMembership(db, requestorNetId)

--- a/src/API/Data/AuthorizationRepository.cs
+++ b/src/API/Data/AuthorizationRepository.cs
@@ -94,16 +94,15 @@ namespace API.Data
                 .Bind(person => ResolveServiceAdminPermissions(person))
                 .Tap(perms => req.SetEntityPermissions(perms)));
 
-        internal static Task<Result<EntityPermissions, Error>> DetermineUnitManagementPermissions(HttpRequest req, string requestorNetId, int unitId, UnitPermissions permissions = UnitPermissions.ManageMembers, EntityPermissions permissionsToGive = PermsGroups.All)
-            => ExecuteDbPipeline($"resolve unit {unitId} and unit member management permissions", db =>
-                FetchPersonAndMembership(db, requestorNetId, unitId)
-                .Bind(person => ResolveUnitManagmentPermissions(person, unitId, new List<UnitPermissions> {permissions}, db, permissionsToGive))
-                .Tap(perms => req.SetEntityPermissions(perms)));
-internal static Task<Result<EntityPermissions, Error>> DetermineUnitManagementPermissions(HttpRequest req, string requestorNetId, int unitId, List<UnitPermissions> permissions, EntityPermissions permissionsToGive = PermsGroups.All)
+        internal static Task<Result<EntityPermissions, Error>> DetermineUnitManagementPermissions(HttpRequest req, string requestorNetId, int unitId, List<UnitPermissions> permissions, EntityPermissions permissionsToGive = PermsGroups.All)
             => ExecuteDbPipeline($"resolve unit {unitId} and unit member management permissions", db =>
                 FetchPersonAndMembership(db, requestorNetId, unitId)
                 .Bind(person => ResolveUnitManagmentPermissions(person, unitId, permissions, db, permissionsToGive))
                 .Tap(perms => req.SetEntityPermissions(perms)));
+        
+        internal static Task<Result<EntityPermissions, Error>> DetermineUnitManagementPermissions(HttpRequest req, string requestorNetId, int unitId, UnitPermissions permissions = UnitPermissions.ManageMembers, EntityPermissions permissionsToGive = PermsGroups.All)
+            => DetermineUnitManagementPermissions(req, requestorNetId, unitId, new List<UnitPermissions> { permissions }, permissionsToGive);
+        
         internal static Task<Result<EntityPermissions, Error>> DetermineUnitMemberToolPermissions(HttpRequest req, string requestorNetId, int membershipId)
             => ExecuteDbPipeline($"resolve unit {membershipId} member management permissions", db =>
                 FetchPersonAndMembership(db, requestorNetId)

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -171,9 +171,7 @@ namespace API.Functions
             string rni = null;
             return Security.Authenticate(req)
                 .Tap(requestor => rni = requestor)
-                .Bind(_ => UnitsRepository.GetMembers(req, unitId))
-                .Bind(members => Pipeline.Success<int>(members.FirstOrDefault(m => m.Netid == rni)?.Id ?? -1))
-                .Bind(unitMemberId => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, rni, unitMemberId))// Set headers saying what the requestor can do to this unit
+                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, new List<UnitPermissions> {UnitPermissions.ManageMembers, UnitPermissions.ManageTools}))// Set headers saying what the requestor can do to this unit
                 .Bind(_ => UnitsRepository.GetTools(req, unitId))
                 .Bind(t => Pipeline.Success(ToolResponse.ConvertList(t)))
                 .Finally(result => Response.Ok(req, result));

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -106,6 +106,50 @@ namespace Integration
             [TestCase(TestEntities.Units.ParksAndRecUnitId, TestEntities.Units.CityOfPawneeUnitId, UnitPermissions.Owner, PermsGroups.GetPut, Description = "Owner Inheritted From Parent")]
             public async Task ReturnsCorrectPermissionsSingleUnit(int unitToCheck, int unitWithPermissions, UnitPermissions providedPermission, EntityPermissions expectedPermission)
                 => await GetReturnsCorrectEntityPermissions($"units/{unitToCheck}", unitWithPermissions, providedPermission, expectedPermission);
+            
+            [Test]
+            public async Task BegottenUnitPermissions()
+            {
+                // Add units 4 levels deep under Parks & Rec unit.
+                var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
+                
+                var childUnit = new Unit("Child", "Child of Parks & Rec", "bleh", "bleh@fake.com", TestEntities.Units.ParksAndRecUnitId);
+                await db.Units.AddAsync(childUnit);
+                await db.SaveChangesAsync();
+
+                var grandChildUnit = new Unit("Grandchild", "Grandchild of Parks & Rec", "bleh", "bleh@fake.com", childUnit.Id);
+                await db.Units.AddAsync(grandChildUnit);
+                await db.SaveChangesAsync();
+
+                var greatGrandChildUnit = new Unit("Great-Grandchild", "Great-Grandchild of Parks & Rec", "bleh", "bleh@fake.com", grandChildUnit.Id);
+                await db.Units.AddAsync(greatGrandChildUnit);
+                await db.SaveChangesAsync();
+
+                var greatGreatGrandChildUnit = new Unit("Great-Great-Grandchild", "Great-Great-Grandchild of Parks & Rec", "bleh", "bleh@fake.com", greatGrandChildUnit.Id);
+                await db.Units.AddAsync(greatGreatGrandChildUnit);
+                await db.SaveChangesAsync();
+
+                // Ron is the owner of the Parks and Rec unit, he should have the same permissions on all child units.
+                var resp = await GetAuthenticated($"units/{TestEntities.Units.ParksAndRecUnitId}", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.GetPut);
+                
+                resp = await GetAuthenticated($"units/{childUnit.Id}", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.GetPut);
+
+                resp = await GetAuthenticated($"units/{grandChildUnit.Id}", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.GetPut);
+
+                resp = await GetAuthenticated($"units/{greatGrandChildUnit.Id}", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.GetPut);
+
+                resp = await GetAuthenticated($"units/{greatGreatGrandChildUnit.Id}", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.GetPut);
+            }
         }
 
         public class UnitCreate : ApiTest
@@ -870,6 +914,50 @@ namespace Integration
             [TestCase(UnitPermissions.Owner, PermsGroups.All, Description = "Owner")]
             public async Task ReturnsCorrectPermissionsForUnitPermissions(UnitPermissions providedPermission, EntityPermissions expectedPermission)
                 => await GetReturnsCorrectEntityPermissions($"units/{TestEntities.Units.AuditorId}/tools", TestEntities.Units.AuditorId, providedPermission, expectedPermission);
+            
+            [Test]
+            public async Task BegottenUnitToolsPermissions()
+            {
+                // Add units 4 levels deep under Parks & Rec unit.
+                var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
+                
+                var childUnit = new Unit("Child", "Child of Parks & Rec", "bleh", "bleh@fake.com", TestEntities.Units.ParksAndRecUnitId);
+                await db.Units.AddAsync(childUnit);
+                await db.SaveChangesAsync();
+
+                var grandChildUnit = new Unit("Grandchild", "Grandchild of Parks & Rec", "bleh", "bleh@fake.com", childUnit.Id);
+                await db.Units.AddAsync(grandChildUnit);
+                await db.SaveChangesAsync();
+
+                var greatGrandChildUnit = new Unit("Great-Grandchild", "Great-Grandchild of Parks & Rec", "bleh", "bleh@fake.com", grandChildUnit.Id);
+                await db.Units.AddAsync(greatGrandChildUnit);
+                await db.SaveChangesAsync();
+
+                var greatGreatGrandChildUnit = new Unit("Great-Great-Grandchild", "Great-Great-Grandchild of Parks & Rec", "bleh", "bleh@fake.com", greatGrandChildUnit.Id);
+                await db.Units.AddAsync(greatGreatGrandChildUnit);
+                await db.SaveChangesAsync();
+
+                // Ron is the owner of the Parks and Rec unit, he should have the same permissions on all child units.
+                var resp = await GetAuthenticated($"units/{TestEntities.Units.ParksAndRecUnitId}/tools", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.All);
+                
+                resp = await GetAuthenticated($"units/{childUnit.Id}/tools", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.All);
+
+                resp = await GetAuthenticated($"units/{grandChildUnit.Id}/tools", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.All);
+
+                resp = await GetAuthenticated($"units/{greatGrandChildUnit.Id}/tools", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.All);
+
+                resp = await GetAuthenticated($"units/{greatGreatGrandChildUnit.Id}/tools", ValidRswansonJwt);
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                AssertPermissions(resp, PermsGroups.All);
+            }
         }
     }
 }


### PR DESCRIPTION
Corey presented an issue where Jolene was in a parent unit as an Owner, but she was unable to edit a child unit's members. This adds tests and resolves the issue on the assumption that Owners, ManageMembers, and ManageTools are all inherited from the parent units (recursively).