### PR TITLE
Use Active Directory to Find Users Not in HrPeople Table

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.11" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="jose-jwt" Version="3.0.0" />

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -165,7 +165,13 @@ namespace API.Data
             }
             catch(Exception ex)
             {
-                Console.WriteLine($"Error: {ex.GetType()}");
+                // for not found responses give a 404
+                if(ex is LdapException && ex.Message == "No Such Object")
+                {
+                    return Pipeline.NotFound($"No user found in Active Directory with username \"{netId}\"");
+                }
+
+                // In other cases just present the error.
                 return Pipeline.InternalServerError($"Encountered an error fetching \"{netId}\" from Active Directory.", ex);
             }
         }

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -290,9 +290,9 @@ namespace API.Data
 
         internal static Task<Result<List<PeopleLookupItem>, Error>> GetAllWithHr(HrPeopleSearchParameters query)
             => ExecuteDbPipeline("search all people by netId", async db => {
-                    var result = await SearchBothByNameOrNetId(db, query);
-                    var x = result.ToList();
-                    return Pipeline.Success(x);
+                    var response = await SearchBothByNameOrNetId(db, query);
+                    var result = response.ToList();
+                    return Pipeline.Success(result);
                 });
     
         public static LdapConnection GetLdapConnection()

--- a/src/API/Data/PeopleRepository.cs
+++ b/src/API/Data/PeopleRepository.cs
@@ -209,7 +209,7 @@ namespace API.Data
             return Pipeline.NotFound("No person, HR person, or Active Directory user found with that netid.");
         }
 
-        public static Result<Person, Error> TryFindPersonWithAd(string netId)
+        public static Result<HrPerson, Error> TryFindPersonWithAd(string netId)
         {
             try
             {
@@ -235,7 +235,7 @@ namespace API.Data
                     //     Console.WriteLine(attr);
                     // }
                     
-                    var adPerson = new Person
+                    var adPerson = new HrPerson
                     {
                         Netid = netId,
                         Name = $"{attributes.getAttribute("givenName")?.StringValue} {attributes.getAttribute("sn")?.StringValue}",
@@ -245,10 +245,8 @@ namespace API.Data
                         Campus = $"{attributes.getAttribute("l")?.StringValue}",
                         CampusPhone = $"{attributes.getAttribute("telephoneNumber")?.StringValue}",
                         CampusEmail = $"{attributes.getAttribute("mail")?.StringValue}",
-                        Location = "",
-                        Expertise = "",
-                        Notes = "",
-                        PhotoUrl = ""
+                        HrDepartment = $"{attributes.getAttribute("division")?.StringValue}",
+                        HrDepartmentDescription = $"{attributes.getAttribute("department")?.StringValue}"
                     };
 
                     return Pipeline.Success(adPerson);

--- a/src/API/Data/UnitMembersRepository.cs
+++ b/src/API/Data/UnitMembersRepository.cs
@@ -95,9 +95,15 @@ namespace API.Data
 			var hrPerson = await db.HrPeople.SingleOrDefaultAsync(p => p.Netid == body.NetId);
 			if (hrPerson == null)
 			{
-				return Pipeline.NotFound("The specified person does not exist in the HR directory.");
+				var adResult = PeopleRepository.TryFindPersonWithAd(body.NetId);
+				if(adResult.IsFailure)
+				{
+					return Pipeline.NotFound("The specified person does not exist in the HR API or Active Directory.");
+				}
+
+				hrPerson = adResult.Value;
 			}
-			
+
 			var matchingDepartment = await db.Departments.SingleOrDefaultAsync(d => d.Name.Equals(hrPerson.HrDepartment));
 			if (matchingDepartment == null)
 			{

--- a/src/API/Functions/People.cs
+++ b/src/API/Functions/People.cs
@@ -112,10 +112,5 @@ namespace API.Functions
             => Security.Authenticate(req)
                 .Bind(_ => PeopleRepository.WithHrGetOne(netId))
                 .Finally(result => Response.Ok(req, result));
-        
-        [FunctionName(nameof(PeopleFromActiveDirectory))]
-        public static Task<IActionResult> PeopleFromActiveDirectory([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/fromAD/{netId}")] HttpRequest req, string netId)
-            => PeopleRepository.GetOneActiveDirectory(netId)
-                .Finally(result => Response.Ok(req, result));
     }
 }

--- a/src/API/Functions/People.cs
+++ b/src/API/Functions/People.cs
@@ -112,5 +112,10 @@ namespace API.Functions
             => Security.Authenticate(req)
                 .Bind(_ => PeopleRepository.WithHrGetOne(netId))
                 .Finally(result => Response.Ok(req, result));
+        
+        [FunctionName(nameof(PeopleFromActiveDirectory))]
+        public static Task<IActionResult> PeopleFromActiveDirectory([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/fromAD/{netId}")] HttpRequest req, string netId)
+            => PeopleRepository.GetOneActiveDirectory(netId)
+                .Finally(result => Response.Ok(req, result));
     }
 }

--- a/src/API/local.settings.json.example
+++ b/src/API/local.settings.json.example
@@ -9,6 +9,8 @@
       "OAuthClientId": "a UAA client ID",
       "OAuthClientSecret": "a UAA client secret",
       "OAuthTokenUrl": "https://apps-test.iu.edu/uaa-stg/oauth/token",
-      "OAuthRedirectUrl": "https://itpeople.apps-test.iu.edu/signin"
+      "OAuthRedirectUrl": "https://itpeople.apps-test.iu.edu/signin",
+      "AdQueryUser":"a username",
+      "AdQueryPassword":"password for AdUser"
     }
 }

--- a/src/Models/DTO/PeopleLookupItem.cs
+++ b/src/Models/DTO/PeopleLookupItem.cs
@@ -2,7 +2,7 @@ namespace Models
 {
 	public class PeopleLookupItem
 	{
-		public int Id {get; set;}
+		public int? Id {get; set;}
 		public string NetId {get; set;}
 		public string Name {get; set;}
 	}


### PR DESCRIPTION
This is specifically to deal with Academic Non-Appointed folks like Andrea Ricci(`anricci`) who never show up in the IMS API, but are real users.

Actually querying LDAP to find them by username was trivial, see `PeopleRepositor.TryFindPersonWithAd()`.

Massaging this into existing pipelines that only expected to find results from the `People` table and `HrPeople` table was rough.  Which is why this commit grew to be so big.
