### PR TITLE
Build Agent NuGet Cache

### DIFF
--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -5,6 +5,7 @@
 
 variables:
   agentPool: 'CSSD-Linux-ELA'
+  NUGET_PACKAGES: '/opt/cssd/nuget'
 
 resources:
   repositories:


### PR DESCRIPTION
This morning we ran out of space on the `/home` mount on build agent `escssdba01`, and `escssdba02` was down to 66 MB free.

The cause was that all the nuget packages, for all of our projects, were getting stored in the `/home/cssd/.nuget` folder, which does not jive with ELA's preferred drive sizes.

The solution is to cache the NuGet packages at `/opt/cssd/nuget` where we have lost of space.  This would be trivial to do if we were super-users on these machines by setting the ENV `NUGET_PACKAGES` to `/opt/cssd/nuget`; but we aren't super-users, and pestering the ELA admins to do it for us is a hassle.

The solution is to let individual pipelines set `NUGET_PACKAGES` for just that run.