### PR TITLE
Bumping Postgres version used in testing

### DIFF
--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -10,7 +10,7 @@ namespace Integration
     public class PostgresContainer : DatabaseContainer
     {
         public PostgresContainer(TextWriter progress, TextWriter error) 
-            : base(progress, error, "postgres:11.7-alpine")
+            : base(progress, error, "postgres:11.16-alpine")
         {
         }
 


### PR DESCRIPTION
This reflects an up-coming upgrade in production & test to Postgres 11.16.26

DockerHub only has a version for 11.16, but that should be close enough.  There **shouldn't** be any breaking changes between 11.16 and the minor version 11.16.26.