### PR TITLE
Staging Frontend UAA Client Setting

### DIFF
--- a/src/Web/wwwroot/appsettings.Staging.json
+++ b/src/Web/wwwroot/appsettings.Staging.json
@@ -2,5 +2,5 @@
 	"APP_WEB_URL": "https://itpeople-test.iu.edu",
 	"API_URL": "https://api.itpeople-test.iu.edu",
 	"UAA_OAUTH2_AUTH_URL": "https://apps-test.iu.edu/uaa-stg/oauth/authorize",
-	"UAA_OAUTH2_CLIENT_ID": "uxo-skunkworks"
+	"UAA_OAUTH2_CLIENT_ID": "itpeople"
 }

--- a/src/Web/wwwroot/appsettings.json
+++ b/src/Web/wwwroot/appsettings.json
@@ -2,5 +2,5 @@
 	"APP_WEB_URL": "https://localhost:5001",
 	"API_URL": "http://localhost:3001",
 	"UAA_OAUTH2_AUTH_URL": "https://apps-test.iu.edu/uaa-stg/oauth/authorize",
-	"UAA_OAUTH2_CLIENT_ID": "uxo-skunkworks"
+	"UAA_OAUTH2_CLIENT_ID": "itpeople"
 }


### PR DESCRIPTION
Updating the staging web app to use the same new UAA clientId for OAuth authentication that have been configured in the staging API.