### PR TITLE
State State Server Fix

### DIFF
--- a/Dockerfile.State
+++ b/Dockerfile.State
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS installer-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS installer-env
 
 # A reddit wizard says copy csproj filtes and do a restore first
 # https://www.reddit.com/r/docker/comments/i34thd/dotnet_core_slow_restore/g0azda1?utm_source=share&utm_medium=web2x&context=3
@@ -18,7 +18,7 @@ COPY pact ./pact/
 RUN mkdir -p home/site/wwwroot && \
     dotnet publish -c Release pact/StateServer/StateServer.csproj --output home/site/wwwroot
 
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0-appservice
+FROM mcr.microsoft.com/azure-functions/dotnet:4-dotnet6-appservice
 WORKDIR /app
 ENV AzureWebJobsScriptRoot=/app/home/site/wwwroot
 ENV AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/pact/StateServer/StateServer.csproj
+++ b/pact/StateServer/StateServer.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -396,7 +396,7 @@ namespace Integration
                 var actual = await resp.Content.ReadAsAsync<ApiError>();
 
                 Assert.AreEqual(1, actual.Errors.Count);
-                Assert.Contains("Unit 1 has child units, with ids: 2, 4, 3. These must be reassigned prior to deletion.", actual.Errors);
+                Assert.Contains("Unit 1 has child units, with ids: 2, 3, 4. These must be reassigned prior to deletion.", actual.Errors);
                 Assert.AreEqual("(none)", actual.Details);
             }
 


### PR DESCRIPTION
A bug was introduced in PR #94 where it would fail to build the docker image for the `Dockerfile.State`, and would instead reuse a previously created image with the expected tag.

The container is used to reset the state of the database between tests, and went unnoticed until the changes were merged into PR #92 and tests started failing because the cached image wasn't truncating all the tables.

This is only an issue when running tests or attempting to deploy the project using the DevOps pipelines, so it will not need its own release, but can be merged into `develop` and be part of the next desired production release.