### PR TITLE
STRY0013086 - Add IP Restrictions to LSP Functions

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -4,6 +4,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="IPNetwork2" Version="2.6.560" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" /><!-- must be manually added or Extensions.OpenApi 1.5.1 breaks -->
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" /><!--  Deployment slot complained w/o this explicit reference. https://github.com/Azure/Azure-Functions/issues/1987#issuecomment-952420935 -->

--- a/src/API/Functions/Lsp.cs
+++ b/src/API/Functions/Lsp.cs
@@ -10,42 +10,45 @@ using API.Data;
 
 namespace API.Functions
 {
-	/// <Summary> This collection of endpoints exists to provide backwards-compatible
-	/// support for some tools used by UIPO and IMS. They are not intended to be used
-	/// by API implementers, and so they are excluded from the OpenAPI docs.</Summary>
+    /// <Summary> This collection of endpoints exists to provide backwards-compatible
+    /// support for some tools used by UIPO and IMS. They are not intended to be used
+    /// by API implementers, and so they are excluded from the OpenAPI docs.</Summary>
     public static class Lsp
-	{
-		[FunctionName(nameof(Lsp.LspList))]
-		[OpenApiIgnore]
-		/// Fetch a list of all LSPs.
-		/// LSPs are defined as any member of a unit that has a support relationship with
+    {
+        [FunctionName(nameof(Lsp.LspList))]
+        [OpenApiIgnore]
+        /// Fetch a list of all LSPs.
+        /// LSPs are defined as any member of a unit that has a support relationship with
         /// one or more departmens. An "LA" is a "local administrator" of LSPs. For IT 
-		/// People this corresponds to an LSP in the Leader or Sublead roles.</Summary>
-		public static Task<IActionResult> LspList(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspList")] HttpRequest req)
-			=> LspRepository.GetLspList()
-				.Finally(result => Response.OkXml(req, result));		
+        /// People this corresponds to an LSP in the Leader or Sublead roles.</Summary>
+        public static Task<IActionResult> LspList(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspList")] HttpRequest req)
+            => Security.ValidateIpAddress(req)
+                .Bind(_ => LspRepository.GetLspList())
+                .Finally(result => Response.OkXml(req, result));
 
-		[FunctionName(nameof(Lsp.LspDepartments))]
-		[OpenApiIgnore]
-		/// Fetch all departments supported by a given LSP.
-		/// For the given netid, collect all the departments supported by all the units of  
-		/// which the person is a member.
-		public static Task<IActionResult> LspDepartments(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspDepartments/{netid}")] HttpRequest req, 
-			string netid)
-			=> LspRepository.GetLspDepartments(netid)
-				.Finally(result => Response.OkXml(req, result));		
+        [FunctionName(nameof(Lsp.LspDepartments))]
+        [OpenApiIgnore]
+        /// Fetch all departments supported by a given LSP.
+        /// For the given netid, collect all the departments supported by all the units of  
+        /// which the person is a member.
+        public static Task<IActionResult> LspDepartments(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspDepartments/{netid}")] HttpRequest req,
+            string netid)
+            => Security.ValidateIpAddress(req)
+                .Bind(_ => LspRepository.GetLspDepartments(netid))
+                .Finally(result => Response.OkXml(req, result));
 
-		[FunctionName(nameof(Lsp.DepartmentLsps))]
-		[OpenApiIgnore]
-		/// Fetch all LSPs supporting a given department.
-		/// For the given department name, collect all the LSPs in all the units supporting
-		/// this department. There is typically only one unit supporting a given department.
-		public static Task<IActionResult> DepartmentLsps(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspsInDept/{department}")] HttpRequest req, 
-			string department)
-			=> LspRepository.GetDepartmentLsps(department)
-				.Finally(result => Response.OkXml(req, result));		
-	}
+        [FunctionName(nameof(Lsp.DepartmentLsps))]
+        [OpenApiIgnore]
+        /// Fetch all LSPs supporting a given department.
+        /// For the given department name, collect all the LSPs in all the units supporting
+        /// this department. There is typically only one unit supporting a given department.
+        public static Task<IActionResult> DepartmentLsps(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "LspdbWebService.svc/LspsInDept/{department}")] HttpRequest req,
+            string department)
+            => Security.ValidateIpAddress(req)
+                .Bind(_ => LspRepository.GetDepartmentLsps(department))
+                .Finally(result => Response.OkXml(req, result));
+    }
 }

--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -222,6 +222,12 @@ namespace API.Middleware
 
         static DateTime Epoch = new DateTime(1970,1,1,0,0,0,0,System.DateTimeKind.Utc);
 
+        public static Result<HttpRequest, Error>  ValidateIpAddress(HttpRequest request){
+            var ipAddress = request.HttpContext.Connection.RemoteIpAddress.ToString();
+            Console.WriteLine("Validate IpAddress {0}", ipAddress);
 
+            return Pipeline.Unauthorized($"Invalid IP Address {ipAddress}");
+            //return Pipeline.Success(request);
+        }
     }
 }

--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -247,13 +247,14 @@ namespace API.Middleware
 
         private static List<IPNetwork> GetAllowedAddressRanges()
         {
-            var textList = Utils.Env("LspFuncsAllowedIpRanges");
-            if (string.IsNullOrWhiteSpace(textList))
+            var rangeList = Utils.Env("LspFuncsAllowedIpRanges");
+
+            if (string.IsNullOrWhiteSpace(rangeList))
             {
                 return new List<IPNetwork>();
             }
 
-            return textList.Split(",") // convert comma-delimited settings string to array
+            return rangeList.Split(",") // convert comma-delimited settings string to array
                 .Select(v => v.Trim()) // trim extra spaces
                 .Select(v => ToIpNetwork(v)) // convert to ip network values
                 .Where(v => v != null)

--- a/src/API/local.settings.json.example
+++ b/src/API/local.settings.json.example
@@ -1,23 +1,23 @@
 {
-    "IsEncrypted": false,
-    "Values": {
-      "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-      "AzureWebJobsSecretStorageType": "files",
-      "AzureWebJobsStorage": "",
-      "AzureWebJobsDisableHomepage": "true",
-      "DatabaseConnectionString": "Server=localhost;Database=ItPeople;User Id=SA;Password=abcd1234@;",
-      "JwtPublicKey":"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjU8NG3DQtS84VF52Azk3VM7uB5aGxSofjlv5BWGCu0285MCMwx62y7n1WYdkRPJkADGJUNST4Ux3kkmgj3djn6a10p4FWXGSPBH9V4GaHfMevlDc1o2CfZOAuLT5/FPF+H2XOnSQT6H6cTVU8Yp0iy2Fm21dk3JEDwred9QDpuegjTG8F/2WS403Qv4s5Nq5ATcHvKPQOBHsnXc2LUH7Mu09g02ro4aXiF2h5ytRsQDVCN3hkzMgR6O06XjUs57bwtmwMSXwhH1u4cexdhOgQcGZ2OH+X9uYjfAAluT8OkDTFMT32OZUdB6qTHZnR91tf5xe/oPc/BEL9TSsWk+O7wIDAQAB\n-----END PUBLIC KEY-----",
-      "OAuthClientId": "a UAA client ID",
-      "OAuthClientSecret": "a UAA client secret",
-      "OAuthTokenUrl": "https://apps-test.iu.edu/uaa-stg/oauth/token",
-      "OAuthRedirectUrl": "https://localhost:5001/signin",
-      "CorsHosts": "*",
-      "AdQueryUser":"a username",
-      "AdQueryPassword":"password for AdUser",
-      
-      "OpenApi__Version": "v2",
-      "OpenApi__DocTitle": "IT People API",
-      "OpenApi__DocDescription": "## Description\nIT People is the canonical source of information about people doing IT work at Indiana University, their responsibilities and interests, and the IT units to which they belong.\n\n## Need Help?\nIf you need help using this API, please contact the Client Service and Support Development team via email at [cssdev@iu.edu](mailto:cssdev@iu.edu). \nThe source code for this [API](https://github.com/indiana-university/itpeople-functions) and the [web front end](https://github.com/indiana-university/itpeople-app) are available on GitHub. We welcome pull requests! \nIf you find a bug or would like to request a feature, please [file an issue in GitHub](https://github.com/indiana-university/itpeople-functions/issues).\n\n## Request/Response Formats\nAll HTTP request and response bodies will be JSON formatted.\n\n## Authentication\nAll requests to this API require an HTTP authentication header in the form `Authorization: Bearer TOKEN`, where the `TOKEN` is any valid JWT issued by the <a href=\"https://github.iu.edu/iu-uits-es/uaa\">UITS UAA</a> service. \nThis API will infer the identity of the requestor from the *user_name* property of the UAA JWT.  \n\nAll data query endpoints (i.e. `GET` endpoints) are publicly accessible with valid authentication.\n\nAll data modification endpoints (i.e. `POST`, `PUT`, `DELETE`) are authorized against the identity of caller, as identified in the JWT *user_name* property. See individual endpoints for authorization details.\n",
-      "OpenApi__DocVersion": "v3"
-    }
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "AzureWebJobsSecretStorageType": "files",
+    "AzureWebJobsStorage": "",
+    "AzureWebJobsDisableHomepage": "true",
+    "DatabaseConnectionString": "Server=localhost;Database=ItPeople;User Id=SA;Password=abcd1234@;",
+    "JwtPublicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjU8NG3DQtS84VF52Azk3VM7uB5aGxSofjlv5BWGCu0285MCMwx62y7n1WYdkRPJkADGJUNST4Ux3kkmgj3djn6a10p4FWXGSPBH9V4GaHfMevlDc1o2CfZOAuLT5/FPF+H2XOnSQT6H6cTVU8Yp0iy2Fm21dk3JEDwred9QDpuegjTG8F/2WS403Qv4s5Nq5ATcHvKPQOBHsnXc2LUH7Mu09g02ro4aXiF2h5ytRsQDVCN3hkzMgR6O06XjUs57bwtmwMSXwhH1u4cexdhOgQcGZ2OH+X9uYjfAAluT8OkDTFMT32OZUdB6qTHZnR91tf5xe/oPc/BEL9TSsWk+O7wIDAQAB\n-----END PUBLIC KEY-----",
+    "OAuthClientId": "a UAA client ID",
+    "OAuthClientSecret": "a UAA client secret",
+    "OAuthTokenUrl": "https://apps-test.iu.edu/uaa-stg/oauth/token",
+    "OAuthRedirectUrl": "https://localhost:5001/signin",
+    "CorsHosts": "*",
+    "AdQueryUser": "a username",
+    "AdQueryPassword": "password for AdUser",
+    "LspFuncsAllowedIpRanges": "127.0.0.1/8",
+    "OpenApi__Version": "v2",
+    "OpenApi__DocTitle": "IT People API",
+    "OpenApi__DocDescription": "## Description\nIT People is the canonical source of information about people doing IT work at Indiana University, their responsibilities and interests, and the IT units to which they belong.\n\n## Need Help?\nIf you need help using this API, please contact the Client Service and Support Development team via email at cssdev@iu.edu(mailto:cssdev@iu.edu). \nThe source code for this API(https://github.com/indiana-university/itpeople-functions) and the web front end(https://github.com/indiana-university/itpeople-app) are available on GitHub. We welcome pull requests! \nIf you find a bug or would like to request a feature, please file an issue in GitHub(https://github.com/indiana-university/itpeople-functions/issues).\n\n## Request/Response Formats\nAll HTTP request and response bodies will be JSON formatted.\n\n## Authentication\nAll requests to this API require an HTTP authentication header in the form `Authorization: Bearer TOKEN`, where the `TOKEN` is any valid JWT issued by the <a href=\"https://github.iu.edu/iu-uits-es/uaa\">UITS UAA</a> service. \nThis API will infer the identity of the requestor from the *user_name* property of the UAA JWT.  \n\nAll data query endpoints (i.e. `GET` endpoints) are publicly accessible with valid authentication.\n\nAll data modification endpoints (i.e. `POST`, `PUT`, `DELETE`) are authorized against the identity of caller, as identified in the JWT *user_name* property. See individual endpoints for authorization details.\n",
+    "OpenApi__DocVersion": "v3"
+  }
 }

--- a/tests/API/Integration/Scaffolding/FunctionAppContainer.cs
+++ b/tests/API/Integration/Scaffolding/FunctionAppContainer.cs
@@ -56,11 +56,15 @@ namespace Integration
             => new Config
                 {
                     Env = new List<string> 
-                    { 
+                    {
                         // Add test-only environment variables here, or
                         // add them in Dockerfile.API
+                        
+                        // for testing, allow all IPv4 and IPv6 ranges to access
+                        // LSP functions
+                        "LspFuncsAllowedIpRanges=0.0.0.0/0,::/0"
                     }
-                };
+            };
 
         public override HostConfig ToHostConfig()
             => new HostConfig()

--- a/tests/API/Unit/SecurityTests.cs
+++ b/tests/API/Unit/SecurityTests.cs
@@ -1,0 +1,96 @@
+﻿using API.Middleware;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Unit
+{
+    public class SecurityTests
+    {
+        // note: ranges contains spaces and ipv6 ranges, but still should work ok
+        private const string AddressRanges = "127.0.0.1/8, 149.159.0.0/16, 2001:4860:4860::8888/32";
+
+        [TestCase("149.159.10.10")]
+        [TestCase("127.0.0.1")]
+        [TestCase("2001:4860:4860:0000:0000:0000:0000:8888")]
+        public void WhenAddressIsInRange(string ipAddress)
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+            Environment.SetEnvironmentVariable("LspFuncsAllowedIpRanges", AddressRanges);
+
+            var result = Security.ValidateIpAddress(context.Request);
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
+        [TestCase("188.159.10.10")]
+        [TestCase("10.0.10.10")]
+        [TestCase("2002:4860:4860:0000:0000:0000:0000:8888")]
+        public void WhenAddressIsNotInRange(string ipAddress)
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+            Environment.SetEnvironmentVariable("LspFuncsAllowedIpRanges", AddressRanges);
+
+            var result = Security.ValidateIpAddress(context.Request);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+            Assert.That(result.Error.Messages.First(),
+                Is.EqualTo($"The ip address {context.Connection.RemoteIpAddress} is not allowed to access this resource."));
+        }
+
+        [TestCase("149.159.10.10")]
+        [TestCase("127.0.0.1")]
+        [TestCase("2001:4860:4860:0000:0000:0000:0000:8888")]
+        public void WhenAddressRangeNotSet(string ipAddress)
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse(ipAddress);
+            Environment.SetEnvironmentVariable("LspFuncsAllowedIpRanges", null);
+
+            var result = Security.ValidateIpAddress(context.Request);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+            Assert.That(result.Error.Messages.First(),
+                Is.EqualTo($"The ip address {context.Connection.RemoteIpAddress} is not allowed to access this resource."));
+
+        }
+
+        [Test]
+        public void WhenAddressRangeContainsInvalidEntry() {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse("149.159.10.10");
+
+            // note: second entry is invalid
+            Environment.SetEnvironmentVariable("LspFuncsAllowedIpRanges", "127.0.0.1/8,149.1590.0/16");
+
+            var result = Security.ValidateIpAddress(context.Request);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+            Assert.That(result.Error.Messages.First(),
+                Is.EqualTo($"The ip address {context.Connection.RemoteIpAddress} is not allowed to access this resource."));
+        }
+
+        // testing logic when range string contains single entry
+        [Test]
+        public void WhenAddressRangeContainsSingleEntry()
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse("127.0.0.1");
+
+            // note: second entry is invalid
+            Environment.SetEnvironmentVariable("LspFuncsAllowedIpRanges", "127.0.0.1/8");
+
+            var result = Security.ValidateIpAddress(context.Request);
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+
+    }
+}


### PR DESCRIPTION
[STRY0013086 - Add IP Restrictions to LSP Functions](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=91f99c4c1b662d1016c02fc4bd4bcbc8%26sysparm_view=scrum)

This pull request adds IP restrictions to the public LSP function endpoint. 

These restrictions are configured via the "LspFuncsAllowedIpRanges" app setting, which takes a comma-delimited list of cidr values. For example: `127.0.0.1/8,149.159.0.0/16`.

If the client's IP address does not fall within the provided ranges, or if no ranges are provided, the public LSP functions will now return 401 Unauthorized.

This code should support IPv4 and IPv6 addresses and CIDR ranges.

### How was this tested?
* Added unit tests to exercise security logic.
* Will test against server once build completes

