### PR TITLE
Tests Use Postgres 14.7

### DIFF
--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -10,7 +10,7 @@ namespace Integration
     public class PostgresContainer : DatabaseContainer
     {
         public PostgresContainer(TextWriter progress, TextWriter error) 
-            : base(progress, error, "postgres:11.7-alpine")
+            : base(progress, error, "postgres:14.7-alpine")
         {
         }
 


### PR DESCRIPTION
This PR is a formality.  The change ensures that our database client works with the version of Postgres our test and production databases will be upgraded to in the near future.