### PR TITLE
STRY0013096 Add Logging For Successful Lsp Functions GET Requests

### DIFF
--- a/src/API/Middleware/Security.cs
+++ b/src/API/Middleware/Security.cs
@@ -2,12 +2,10 @@ using CSharpFunctionalExtensions;
 using Jose;
 using Microsoft.AspNetCore.Http;
 using Models;
-using Novell.Directory.Ldap;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.OpenSsl;
-using Org.BouncyCastle.Security;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -16,9 +14,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using YamlDotNet.Core.Tokens;
 
 namespace API.Middleware
 {
@@ -224,7 +220,7 @@ namespace API.Middleware
             return csp;
         }
 
-        static DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
+        static DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
         public static Result<HttpRequest, Error> ValidateIpAddress(HttpRequest request)
         {
@@ -238,13 +234,11 @@ namespace API.Middleware
             // return success
             if (allowedRanges.Any(r => r.Contains(ipAddress)))
             {
-                Logging.GetLogger(request).Information($"Validate IP address success: {request.Path} {ipAddress}");
                 return Pipeline.Success(request);
             }
 
             // otherwise return failure
-            Logging.GetLogger(request).Information($"Validate IP address failure: {request.Path} {ipAddress}");
-            return Pipeline.Unauthorized($"The ip address {ipAddress} is not allowed to access this resource.");
+            return Pipeline.Unauthorized($"The ip address {ipAddress} is not allowed to access this resource."); 
         }
 
         private static List<IPNetwork> GetAllowedAddressRanges()
@@ -270,5 +264,6 @@ namespace API.Middleware
                 : null;
         }
 
+        
     }
 }


### PR DESCRIPTION
[STRY0013096 - Add Logging For Successful Lsp Functions GET Requests](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=cb40d2291b22ad5016c02fc4bd4bcb2d%26sysparm_view=scrum)

This PR updates the IT People logging logic so that successful GET requests against the legacy LSP functions are logged. It also removes the custom logging logic from the `Security.ValidateIpAddress` method. 

Normally, successful GET requests are not logged, but we want to log successful GET requests against the LSP functions, as these functions are now IP restricted and we may be asked to audit their usage. After this change, successful GET requests to the LSP functions will be logged. Failed GET requests were already logged.

Finally, I've removed the custom logging code from the `Security.ValidateIpAddress` method, as it is now redundant.