### PR TITLE
Build Agent Housekeeping

### DIFF
--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -48,6 +48,7 @@ stages:
       inputs:
         script: |
           docker image prune --filter "until=48h" --force
+          docker system prune --volumes --filter "until=48h" --force
           docker builder prune --force
 
 - stage: Package

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -48,7 +48,7 @@ stages:
       inputs:
         script: |
           docker image prune --filter "until=48h" --force
-          docker system prune --volumes --filter "until=48h" --force
+          docker system prune --volumes -force
           docker builder prune --force
 
 - stage: Package

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -40,7 +40,15 @@ stages:
     - task: DotNetCoreCLI@2
       inputs:
         command: test
-        projects: tests/API/Integration/Integration.csproj  
+        projects: tests/API/Integration/Integration.csproj
+    
+    - task: CmdLine@2
+      displayName: Prune old Docker images and cache
+      continueOnError: true # If this task fails keep on truckin'. It's just house keeping
+      inputs:
+        script: |
+          docker image prune --filter "until=48h" --force
+          docker builder prune --force
 
 - stage: Package
   displayName: Package  

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -48,7 +48,7 @@ stages:
       inputs:
         script: |
           docker image prune --filter "until=48h" --force
-          docker system prune --volumes -force
+          docker system prune --volumes --force
           docker builder prune --force
 
 - stage: Package


### PR DESCRIPTION
## ServiceNow Story Number and Description
[STRY0012376](https://iu.service-now.com/nav_to.do?uri=rm_story.do?sys_id=4a197d7c4790d9909286dfbd436d4315%26sysparm_view=scrum) - Cleanup Steps for Docker Tasks on Linux Build Agents

## Motivation and Context
On our Linux build agents we sometimes run out f space on the device where our Docker data is stored.  These changes ensure that we are disposing of unused images, volumes, and cached build artifacts.

## How was this tested?
I have used the new commands locally and on one of the build agents, but running this pipeline for the test environment will be the most meaningful test.