### PR TITLE
STRY0013383 - Bug - Empty Options Request Against Site Root Causes 500 Error

### DIFF
--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -89,7 +89,7 @@ namespace API.Middleware
         public static ILogger GetLogger(HttpRequest req)
         {
             var pathParts = req.Path.HasValue
-                ? req.Path.Value.Split("/", System.StringSplitOptions.RemoveEmptyEntries)
+                ? req.Path.Value.Split("/", StringSplitOptions.RemoveEmptyEntries)
                 : new[]{string.Empty};
 
             var elapsed = 
@@ -101,7 +101,7 @@ namespace API.Middleware
                 .ForContext(LogProps.ElapsedTime, elapsed)
                 .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
                 .ForContext(LogProps.RequestMethod, req.Method)
-                .ForContext(LogProps.Function, pathParts.First())
+                .ForContext(LogProps.Function, pathParts.FirstOrDefault())
                 .ForContext(LogProps.RequestParameters, string.Join('/', pathParts.Skip(1)))
                 .ForContext(LogProps.RequestQuery, req.QueryString)
                 .ForContext(LogProps.RequestorNetid, req.HttpContext.Items[LogProps.RequestorNetid]);


### PR DESCRIPTION
## ServiceNow Story Number and Description
[STRY0013383 - Bug - Empty Options Request Against Site Root Causes 500 Error](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=1532aedf1bdbe99016c02fc4bd4bcb75%26sysparm_view=scrum)

## Motivation and Context
There is an issue in the logger code that causes a 500 error when an `OPTIONS` request is made against the root of the site. The PR addresses the issue.

The issue originates in these lines of `Api/Middleware/Logging.cs`

https://github.com/indiana-university/itpeople-functions-v2/blob/7710bcced6363bda28d50edb65940616abab7b45/src/API/Middleware/Logging.cs#L91-L93

In the case of an options request against the root of the site, `req.Path` comes in as "\", so it has a value. Accordingly, the `HasValue` logic path splits the path using "\" as a delimiter, removing empty items from the array. This results in an empty array. Then in line 104 of the same method, we call `pathParts.First()`, which raises a no-elements exception, etc.

The fix here is to change line 104 from `pathParts.First()` to `pathParts.FirstOrDefault()`.

## How was this tested?

* Confirmed behavior on local machine
* Confirmed behavior on test server