### PR TITLE
STRY0013055 Api Returns 500 Errors When Passed a String

### DIFF
--- a/src/API/Functions/BuildingRelationships.cs
+++ b/src/API/Functions/BuildingRelationships.cs
@@ -17,74 +17,84 @@ using System.Linq;
 
 namespace API.Functions
 {
-	public static class BuildingRelationships
-	{
-		public const string BuildingRelationshipsTitle = "Building Relationships";
+    public static class BuildingRelationships
+    {
+        public const string BuildingRelationshipsTitle = "Building Relationships";
 
-		[FunctionName(nameof(BuildingRelationships.BuildingRelationshipsGetAll))]
-		[OpenApiOperation(nameof(BuildingRelationships.BuildingRelationshipsGetAll), BuildingRelationshipsTitle, Summary = "List all unit-building support relationships")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<BuildingRelationshipResponse>), Description = "A collection of building support relationship records")]
-		public static Task<IActionResult> BuildingRelationshipsGetAll(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildingRelationships")] HttpRequest req)
-			=> Security.Authenticate(req)
-				.Bind(_ => BuildingRelationshipsRepository.GetAll())
-				.Bind(br => Pipeline.Success(br.Select(brx => new BuildingRelationshipResponse(brx)).ToList()))
-				.Finally(r => Response.Ok(req, r));
+        [FunctionName(nameof(BuildingRelationships.BuildingRelationshipsGetAll))]
+        [OpenApiOperation(nameof(BuildingRelationships.BuildingRelationshipsGetAll), BuildingRelationshipsTitle, Summary = "List all unit-building support relationships")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<BuildingRelationshipResponse>), Description = "A collection of building support relationship records")]
+        public static Task<IActionResult> BuildingRelationshipsGetAll(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildingRelationships")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(_ => BuildingRelationshipsRepository.GetAll())
+                .Bind(br => Pipeline.Success(br.Select(brx => new BuildingRelationshipResponse(brx)).ToList()))
+                .Finally(r => Response.Ok(req, r));
 
-		[FunctionName(nameof(BuildingRelationships.BuildingRelationshipsGetOne))]
-		[OpenApiOperation(nameof(BuildingRelationships.BuildingRelationshipsGetOne), BuildingRelationshipsTitle, Summary = "Find a unit-building support relationships by ID")]
-		[OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the building support relationship record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(BuildingRelationshipResponse), Description = "A building support relationship record")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No support relationship was found with the ID provided.")]
-		public static Task<IActionResult> BuildingRelationshipsGetOne(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildingRelationships/{relationshipId}")] HttpRequest req, int relationshipId)
-			=> Security.Authenticate(req)
-				.Bind(_ => BuildingRelationshipsRepository.GetOne(relationshipId))
-				.Bind(br => Pipeline.Success(new BuildingRelationshipResponse(br)))
-				.Finally(result => Response.Ok(req, result));
+        [FunctionName(nameof(BuildingRelationships.BuildingRelationshipsGetOne))]
+        [OpenApiOperation(nameof(BuildingRelationships.BuildingRelationshipsGetOne), BuildingRelationshipsTitle, Summary = "Find a unit-building support relationships by ID")]
+        [OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the building support relationship record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(BuildingRelationshipResponse), Description = "A building support relationship record")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No support relationship was found with the ID provided.")]
+        public static Task<IActionResult> BuildingRelationshipsGetOne(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildingRelationships/{relationshipId}")] HttpRequest req, string relationshipId)
+            => Utils.ConvertParam(relationshipId, nameof(relationshipId))
+                .Bind(id => BuildingRelationshipsGetOneInternal(req, id))
+                .Bind(br => Pipeline.Success(new BuildingRelationshipResponse(br)))
+                .Finally(result => Response.Ok(req, result));
 
-		[FunctionName(nameof(BuildingRelationships.CreateBuildingRelationship))]
-		[OpenApiOperation(nameof(BuildingRelationships.CreateBuildingRelationship), BuildingRelationshipsTitle, Summary = "Create a unit-building support relationship", Description = "Authorization: Support relationships can be created by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(BuildingRelationshipRequest), Required = true)]
-		[OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(BuildingRelationshipResponse), Description = "The newly created building support relationship record")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The request body was malformed, the unitId and/or buildingId field was missing.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified unit and/or building does not exist.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided unit already has a support relationship with the provided building.")]
+        private static Task<Result<BuildingRelationship, Error>> BuildingRelationshipsGetOneInternal(HttpRequest req, int relationshipId)
+            => Security.Authenticate(req)
+                .Bind(_ => BuildingRelationshipsRepository.GetOne(relationshipId));
 
-		public static Task<IActionResult> CreateBuildingRelationship(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "buildingRelationships")] HttpRequest req)
-		{
-			string requestorNetId = null;
-			BuildingRelationshipRequest buildingRelationshipRequest = null;
-			return Security.Authenticate(req)
-			.Tap(requestor => requestorNetId = requestor)
-			.Bind(requestor => Request.DeserializeBody<BuildingRelationshipRequest>(req))
-			.Tap(brr => buildingRelationshipRequest = brr)
-			.Bind(brr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, brr.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
-			.Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
-			.Bind(authorized => BuildingRelationshipsRepository.CreateBuildingRelationship(buildingRelationshipRequest))
-			.Bind(br => Pipeline.Success(new BuildingRelationshipResponse(br)))
-			.Finally(result => Response.Created(req, result));
-		}
+        [FunctionName(nameof(BuildingRelationships.CreateBuildingRelationship))]
+        [OpenApiOperation(nameof(BuildingRelationships.CreateBuildingRelationship), BuildingRelationshipsTitle, Summary = "Create a unit-building support relationship", Description = "Authorization: Support relationships can be created by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(BuildingRelationshipRequest), Required = true)]
+        [OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(BuildingRelationshipResponse), Description = "The newly created building support relationship record")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The request body was malformed, the unitId and/or buildingId field was missing.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified unit and/or building does not exist.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided unit already has a support relationship with the provided building.")]
 
-		[FunctionName(nameof(BuildingRelationships.DeleteBuildingRelationship))]
-		[OpenApiOperation(nameof(BuildingRelationships.DeleteBuildingRelationship), BuildingRelationshipsTitle, Summary = "Delete a unit-building support relationship", Description = "Authorization: Support relationships can be deleted by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the building support relationship record.")]
-		[OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No building support relationship was found with the ID provided.")]
-		public static Task<IActionResult> DeleteBuildingRelationship(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships/{relationshipId}")] HttpRequest req, int relationshipId)
-		{
-				string requestorNetId = null;
-				return Security.Authenticate(req)
-					.Tap(requestor => requestorNetId = requestor)
-					.Bind(requestor => BuildingRelationshipsRepository.GetOne(relationshipId))
-					.Bind(br => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, br.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
-					.Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
-					.Bind(_ => BuildingRelationshipsRepository.DeleteBuildingRelationship(req, relationshipId))
-					.Finally(result => Response.NoContent(req, result));
-		}
-	}
+
+        public static Task<IActionResult> CreateBuildingRelationship(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "buildingRelationships")] HttpRequest req)
+        {
+            string requestorNetId = null;
+            BuildingRelationshipRequest buildingRelationshipRequest = null;
+            return Security.Authenticate(req)
+            .Tap(requestor => requestorNetId = requestor)
+            .Bind(requestor => Request.DeserializeBody<BuildingRelationshipRequest>(req))
+            .Tap(brr => buildingRelationshipRequest = brr)
+            .Bind(brr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, brr.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
+            .Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
+            .Bind(authorized => BuildingRelationshipsRepository.CreateBuildingRelationship(buildingRelationshipRequest))
+            .Bind(br => Pipeline.Success(new BuildingRelationshipResponse(br)))
+            .Finally(result => Response.Created(req, result));
+        }
+
+        [FunctionName(nameof(BuildingRelationships.DeleteBuildingRelationship))]
+        [OpenApiOperation(nameof(BuildingRelationships.DeleteBuildingRelationship), BuildingRelationshipsTitle, Summary = "Delete a unit-building support relationship", Description = "Authorization: Support relationships can be deleted by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the building support relationship record.")]
+        [OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No building support relationship was found with the ID provided.")]
+        public static Task<IActionResult> DeleteBuildingRelationship(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "buildingRelationships/{relationshipId}")] HttpRequest req, string relationshipId)
+            => Utils.ConvertParam(relationshipId, nameof(relationshipId))
+            .Bind(id => DeleteBuildingRelationshipInternal(req, id))
+            .Finally(result => Response.NoContent(req, result));
+
+        private static Task<Result<bool, Error>> DeleteBuildingRelationshipInternal(HttpRequest req, int relationshipId)
+        {
+            string requestorNetId = null;
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(requestor => BuildingRelationshipsRepository.GetOne(relationshipId))
+                .Bind(br => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, br.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
+                .Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
+                .Bind(_ => BuildingRelationshipsRepository.DeleteBuildingRelationship(req, relationshipId));
+        }
+
+    }
 }

--- a/src/API/Functions/Buildings.cs
+++ b/src/API/Functions/Buildings.cs
@@ -19,13 +19,13 @@ namespace API.Functions
 {
     public static class Buildings
     {
-		[FunctionName(nameof(Buildings.BuildingsGetAll))]
-        [OpenApiOperation(nameof(Buildings.BuildingsGetAll), nameof(Buildings), Summary="List all buildings", Description = @"Get a list of university buildings." )]
-        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<Building>), Description="A collection of building records")]
-        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ApiError), Description="The search query was malformed or incorrect. See response content for additional information.")]
-        [OpenApiParameter("q", In=ParameterLocation.Query, Description="filter by building address/code/name, ex: 'ballantine'")]
+        [FunctionName(nameof(Buildings.BuildingsGetAll))]
+        [OpenApiOperation(nameof(Buildings.BuildingsGetAll), nameof(Buildings), Summary = "List all buildings", Description = @"Get a list of university buildings.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<Building>), Description = "A collection of building records")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
+        [OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by building address/code/name, ex: 'ballantine'")]
         public static Task<IActionResult> BuildingsGetAll(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildings")] HttpRequest req) 
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildings")] HttpRequest req)
             => Security.Authenticate(req)
                 .Bind(_ => BuildingSearchParameters.Parse(req))
                 .Bind(query => BuildingsRepository.GetAll(query))
@@ -34,25 +34,33 @@ namespace API.Functions
         [FunctionName(nameof(Buildings.BuildingsGetOne))]
         [OpenApiOperation(nameof(Buildings.BuildingsGetOne), nameof(Buildings), Summary = "Find a building by ID")]
         [OpenApiParameter("buildingId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the building record.")]
-        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(Building), Description="A building record")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(Building), Description = "A building record")]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No building was found with the ID provided.")]
         public static Task<IActionResult> BuildingsGetOne(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildings/{buildingId}")] HttpRequest req, int buildingId) 
-            => Security.Authenticate(req)
-                .Bind(_ => BuildingsRepository.GetOne(buildingId))
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildings/{buildingId}")] HttpRequest req, string buildingId)
+            => Utils.ConvertParam(buildingId, nameof(buildingId))
+                .Bind(id => BuildingsGetOneInternal(req, id))
                 .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<Building, Error>> BuildingsGetOneInternal(HttpRequest req, int buildingId)
+            => Security.Authenticate(req)
+                .Bind(_ => BuildingsRepository.GetOne(buildingId));
 
         [FunctionName(nameof(Buildings.BuildingsGetSupportingUnits))]
         [OpenApiOperation(nameof(Buildings.BuildingsGetSupportingUnits), nameof(Buildings), Summary = "List a building's supporting units", Description = @"A supporting unit provides IT services for the building.")]
         [OpenApiParameter("buildingId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the building record.")]
-        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<BuildingRelationshipResponse>), Description="A collection of building relationship records")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<BuildingRelationshipResponse>), Description = "A collection of building relationship records")]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No building relationships were found with the buildingId provided.")]
         public static Task<IActionResult> BuildingsGetSupportingUnits(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildings/{buildingId}/supportingUnits")] HttpRequest req, int buildingId) 
-            => Security.Authenticate(req)
-                .Bind(_ => BuildingsRepository.GetOne(buildingId)) //make sure the building exists before trying to get its supporting units
-                .Bind(_ => BuildingsRepository.GetSupportingUnits(buildingId))
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "buildings/{buildingId}/supportingUnits")] HttpRequest req, string buildingId)
+            => Utils.ConvertParam(buildingId, nameof(buildingId))
+                .Bind(id => BuildingsGetSupportingUnitsInternal(req, id)) //make sure the building exists before trying to get its supporting units
                 .Bind(br => Pipeline.Success(br.Select(brx => new BuildingRelationshipResponse(brx)).ToList()))
                 .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<BuildingRelationship>, Error>> BuildingsGetSupportingUnitsInternal(HttpRequest req, int buildingId)
+            => Security.Authenticate(req)
+                .Bind(_ => BuildingsRepository.GetOne(buildingId)) //make sure the building exists before trying to get its supporting units
+                .Bind(_ => BuildingsRepository.GetSupportingUnits(buildingId));
     }
 }

--- a/src/API/Functions/Departments.cs
+++ b/src/API/Functions/Departments.cs
@@ -16,55 +16,67 @@ using System.Net.Mime;
 
 namespace API.Functions
 {
-	public static class Departments
-	{
-		[FunctionName(nameof(Departments.DepartmentsGetAll))]
-		[OpenApiOperation(nameof(Departments.DepartmentsGetAll), nameof(Departments), Summary = "List all Departments", Description = @"Get a list of university Departments.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<Department>), Description = "A collection of department records")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
-		[OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by department name/description, ex: 'Parks' or 'PA-PARK'")]
-		[OpenApiParameter("_limit", In = ParameterLocation.Query, Description = "Restrict the number of responses to no more than this integer. ex: `15` or `20`.  `0` or less will return all records.")]
-		public static Task<IActionResult> DepartmentsGetAll(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments")] HttpRequest req)
-			=> Security.Authenticate(req)
-				.Bind(_ => DepartmentSearchParameters.Parse(req))
-				.Bind(query => DepartmentsRepository.GetAll(query))
-				.Finally(Departments => Response.Ok(req, Departments));
+    public static class Departments
+    {
+        [FunctionName(nameof(Departments.DepartmentsGetAll))]
+        [OpenApiOperation(nameof(Departments.DepartmentsGetAll), nameof(Departments), Summary = "List all Departments", Description = @"Get a list of university Departments.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<Department>), Description = "A collection of department records")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
+        [OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by department name/description, ex: 'Parks' or 'PA-PARK'")]
+        [OpenApiParameter("_limit", In = ParameterLocation.Query, Description = "Restrict the number of responses to no more than this integer. ex: `15` or `20`.  `0` or less will return all records.")]
+        public static Task<IActionResult> DepartmentsGetAll(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(_ => DepartmentSearchParameters.Parse(req))
+                .Bind(query => DepartmentsRepository.GetAll(query))
+                .Finally(Departments => Response.Ok(req, Departments));
 
-		[FunctionName(nameof(Departments.DepartmentsGetOne))]
-		[OpenApiOperation(nameof(Departments.DepartmentsGetOne), nameof(Departments), Summary = "Find a department by ID")]
-		[OpenApiParameter("departmentId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(Department), Description = "A department record")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department was found with the ID provided.")]
-		public static Task<IActionResult> DepartmentsGetOne(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments/{departmentId}")] HttpRequest req, int departmentId)
-			=> Security.Authenticate(req)
-				.Bind(_ => DepartmentsRepository.GetOne(departmentId))
-				.Finally(result => Response.Ok(req, result));
-		
+        [FunctionName(nameof(Departments.DepartmentsGetOne))]
+        [OpenApiOperation(nameof(Departments.DepartmentsGetOne), nameof(Departments), Summary = "Find a department by ID")]
+        [OpenApiParameter("departmentId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(Department), Description = "A department record")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department was found with the ID provided.")]
+        public static Task<IActionResult> DepartmentsGetOne(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments/{departmentId}")] HttpRequest req, string departmentId)
+            => Utils.ConvertParam(departmentId, nameof(departmentId))
+                .Bind(id => DepartmentsGetOneInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<Department, Error>> DepartmentsGetOneInternal(HttpRequest req, int departmentId)
+            => Security.Authenticate(req)
+                .Bind(_ => DepartmentsRepository.GetOne(departmentId));
+
         [FunctionName(nameof(Departments.DepartmentsGetMemberUnits))]
-		[OpenApiOperation(nameof(Departments.DepartmentsGetMemberUnits), nameof(Departments), Summary = "List a department's member units", Description="A member unit contains people that have an HR relationship with the department.")]
-		[OpenApiParameter("departmentId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<UnitResponse>), Description = "A collection of unit records")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department was found with the ID provided.")]
-		public static Task<IActionResult> DepartmentsGetMemberUnits(
-					[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments/{departmentId}/memberUnits")] HttpRequest req, int departmentId)
-					=> Security.Authenticate(req)
-						.Bind(_ => DepartmentsRepository.GetOne(departmentId))
-						.Bind(_ => DepartmentsRepository.GetMemberUnits(departmentId))
-						.Finally(result => Response.Ok(req, result));
+        [OpenApiOperation(nameof(Departments.DepartmentsGetMemberUnits), nameof(Departments), Summary = "List a department's member units", Description = "A member unit contains people that have an HR relationship with the department.")]
+        [OpenApiParameter("departmentId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<UnitResponse>), Description = "A collection of unit records")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department was found with the ID provided.")]
+        public static Task<IActionResult> DepartmentsGetMemberUnits(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments/{departmentId}/memberUnits")] HttpRequest req, string departmentId)
+            => Utils.ConvertParam(departmentId, nameof(departmentId))
+                .Bind(id => DepartmentsGetMemberUnitsInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
 
-		[FunctionName(nameof(Departments.DepartmentsGetSupportingUnits))]
-		[OpenApiOperation(nameof(Departments.DepartmentsGetSupportingUnits), nameof(Departments), Summary = "List a department's supporting units", Description="A supporting unit provides IT services for the department.")]
-		[OpenApiParameter("departmentId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<SupportRelationshipResponse>), Description = "A collection of support relationship records")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department was found with the ID provided.")]
-		public static Task<IActionResult> DepartmentsGetSupportingUnits(
-					[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments/{departmentId}/supportingUnits")] HttpRequest req, int departmentId)
-					=> Security.Authenticate(req)
-						.Bind(_ => DepartmentsRepository.GetOne(departmentId))
-						.Bind(_ => DepartmentsRepository.GetSupportingUnits(departmentId))
-						.Bind(sr => Pipeline.Success(SupportRelationshipResponse.ConvertList(sr)))
-						.Finally(result => Response.Ok(req, result));
-	}
+        private static Task<Result<List<Unit>, Error>> DepartmentsGetMemberUnitsInternal(HttpRequest req, int departmentId)
+            => Security.Authenticate(req)
+                .Bind(_ => DepartmentsRepository.GetOne(departmentId))
+                .Bind(_ => DepartmentsRepository.GetMemberUnits(departmentId));
+
+        [FunctionName(nameof(Departments.DepartmentsGetSupportingUnits))]
+        [OpenApiOperation(nameof(Departments.DepartmentsGetSupportingUnits), nameof(Departments), Summary = "List a department's supporting units", Description = "A supporting unit provides IT services for the department.")]
+        [OpenApiParameter("departmentId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(List<SupportRelationshipResponse>), Description = "A collection of support relationship records")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department was found with the ID provided.")]
+        public static Task<IActionResult> DepartmentsGetSupportingUnits(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "departments/{departmentId}/supportingUnits")] HttpRequest req, string departmentId)
+            => Utils.ConvertParam(departmentId, nameof(departmentId))
+                .Bind(id => DepartmentsGetSupportingUnitsInternal(req, id))
+                .Bind(sr => Pipeline.Success(SupportRelationshipResponse.ConvertList(sr)))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<SupportRelationship>, Error>> DepartmentsGetSupportingUnitsInternal(HttpRequest req, int departmentId)
+            => Security.Authenticate(req)
+                .Bind(_ => DepartmentsRepository.GetOne(departmentId))
+                .Bind(_ => DepartmentsRepository.GetSupportingUnits(departmentId));
+    }
 }

--- a/src/API/Functions/People.cs
+++ b/src/API/Functions/People.cs
@@ -19,18 +19,18 @@ namespace API.Functions
     public static class People
     {
         [FunctionName(nameof(People.PeopleGetAll))]
-        [OpenApiOperation(nameof(People.PeopleGetAll), nameof(People), Summary="Search all people", Description = @"Search results are unioned within a filter and intersected across filters. For example, `interest=node, lambda` will return people with an interest in either `node` OR `lambda`, whereas `role=ItLeadership&interest=node` will only return people who are both in `ItLeadership AND have an interest in `node`." )]
+        [OpenApiOperation(nameof(People.PeopleGetAll), nameof(People), Summary = "Search all people", Description = @"Search results are unioned within a filter and intersected across filters. For example, `interest=node, lambda` will return people with an interest in either `node` OR `lambda`, whereas `role=ItLeadership&interest=node` will only return people who are both in `ItLeadership AND have an interest in `node`.")]
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<Person>))]
-        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description="The search query was malformed or incorrect. See response content for additional information.")]
-        [OpenApiParameter("q", In=ParameterLocation.Query, Description="filter by name/netid, ex: `Ron` or `rswanso`")]
-        [OpenApiParameter("class", In=ParameterLocation.Query, Type=typeof(ResponsibilitiesPropDoc), Description="filter by job classification/responsibility, ex: `UserExperience` or `UserExperience, WebAdminDevEng`")]
-        [OpenApiParameter("interest", In=ParameterLocation.Query, Description="filter by one interests, ex: `serverless` or `node, lambda`")]
-        [OpenApiParameter("campus", In=ParameterLocation.Query, Description="filter by primary campus: `Bloomington`, `Indianapolis`, `Columbus`, `East`, `Fort Wayne`, `Kokomo`, `Northwest`, `South Bend`, `Southeast`")]
-        [OpenApiParameter("role", In=ParameterLocation.Query, Type=typeof(Role), Description="filter by unit role, ex: `Leader` or `Leader, Member`")]
-        [OpenApiParameter("permission", In=ParameterLocation.Query, Type=typeof(UnitPermissions), Description="filter by unit permissions, ex: `Owner` or `Owner, ManageMembers`")]
-        [OpenApiParameter("area", In=ParameterLocation.Query, Type=typeof(Area), Description="filter by unit area, e.g. `uits` or `edge`")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
+        [OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by name/netid, ex: `Ron` or `rswanso`")]
+        [OpenApiParameter("class", In = ParameterLocation.Query, Type = typeof(ResponsibilitiesPropDoc), Description = "filter by job classification/responsibility, ex: `UserExperience` or `UserExperience, WebAdminDevEng`")]
+        [OpenApiParameter("interest", In = ParameterLocation.Query, Description = "filter by one interests, ex: `serverless` or `node, lambda`")]
+        [OpenApiParameter("campus", In = ParameterLocation.Query, Description = "filter by primary campus: `Bloomington`, `Indianapolis`, `Columbus`, `East`, `Fort Wayne`, `Kokomo`, `Northwest`, `South Bend`, `Southeast`")]
+        [OpenApiParameter("role", In = ParameterLocation.Query, Type = typeof(Role), Description = "filter by unit role, ex: `Leader` or `Leader, Member`")]
+        [OpenApiParameter("permission", In = ParameterLocation.Query, Type = typeof(UnitPermissions), Description = "filter by unit permissions, ex: `Owner` or `Owner, ManageMembers`")]
+        [OpenApiParameter("area", In = ParameterLocation.Query, Type = typeof(Area), Description = "filter by unit area, e.g. `uits` or `edge`")]
         public static Task<IActionResult> PeopleGetAll(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people")] HttpRequest req) 
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people")] HttpRequest req)
             => Security.Authenticate(req)
                 .Bind(_ => PeopleSearchParameters.Parse(req))
                 .Bind(query => PeopleRepository.GetAll(query))
@@ -42,18 +42,18 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(Person))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No person was found with the provided ID.")]
         public static Task<IActionResult> PeopleGetOne(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}")] HttpRequest req, string id) 
-            =>  Security.Authenticate(req)
-                .Bind(requestor => 
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}")] HttpRequest req, string id)
+            => Security.Authenticate(req)
+                .Bind(requestor =>
                     int.TryParse(id, out int value)
                     ? AuthorizationRepository.DeterminePersonPermissions(req, requestor, value)
                     : AuthorizationRepository.DeterminePersonPermissions(req, requestor, id))
-                .Bind(_ => 
+                .Bind(_ =>
                     int.TryParse(id, out int value)
                     ? PeopleRepository.GetOne(value)
                     : PeopleRepository.GetOne(id))
-                .Finally(result => Response.Ok(req, result));                    
-            
+                .Finally(result => Response.Ok(req, result));
+
 
         [FunctionName(nameof(People.PeopleGetMemberships))]
         [OpenApiOperation(nameof(People.PeopleGetMemberships), nameof(People), Summary = "List unit memberships", Description = "List all units for which this person does IT work.")]
@@ -61,41 +61,45 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<UnitMemberResponse>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No person was found with the provided ID.")]
         public static Task<IActionResult> PeopleGetMemberships(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}/memberships")] HttpRequest req, string id) 
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people/{id}/memberships")] HttpRequest req, string id)
             => Security.Authenticate(req)
-                .Bind(_ => 
+                .Bind(_ =>
                     int.TryParse(id, out int value)
                     ? PeopleRepository.GetMemberships(value)
                     : PeopleRepository.GetMemberships(id))
                 .Finally(result => Response.Ok(req, result));
-                
+
         [FunctionName(nameof(People.PeopleUpdate))]
         [OpenApiOperation(nameof(People.PeopleUpdate), nameof(People), Summary = "Update person information", Description = "Update a person's location, expertise, and responsibilities/job classes.\n\n_Authorization_: The JWT must represent either the person whose record is being modified (i.e., a person can modify their own record), or someone who has permissions to manage a unit of which this person is a member (i.e., typically that person's manager/supervisor.)")]
-        [OpenApiParameter("id", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the person record.")]
+        [OpenApiParameter("personId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the person record.")]
         [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(PersonUpdateRequest))]
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(Person))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No person was found with the provided ID.")]
         [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The request body was missing or malformed.")]
         [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You do not have permission to modify this person.")]
         public static Task<IActionResult> PeopleUpdate(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "people/{id}")] HttpRequest req, int id) 
+            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "people/{personId}")] HttpRequest req, string personId)
+            => Utils.ConvertParam(personId, nameof(personId))
+                .Bind(id => PeopleUpdateInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<Person, Error>> PeopleUpdateInternal(HttpRequest req, int id)
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DeterminePersonPermissions(req, requestor, id))
                 .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
                 .Bind(_ => Request.DeserializeBody<PersonUpdateRequest>(req))
-                .Bind(body => PeopleRepository.Update(req, id, body))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(body => PeopleRepository.Update(req, id, body));
 
 
         //Check people table first, if no records check HR people
         [FunctionName(nameof(People.PeopleLookup))]
-        [OpenApiOperation(nameof(People.PeopleLookup), nameof(People), Summary="Search all staff", Description = @"Search for staff, including IT People, by name or username (netid)." )]
+        [OpenApiOperation(nameof(People.PeopleLookup), nameof(People), Summary = "Search all staff", Description = @"Search for staff, including IT People, by name or username (netid).")]
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<PeopleLookupItem>))]
-        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description="The search query was malformed or incorrect. See response content for additional information.")]
-        [OpenApiParameter("q", In=ParameterLocation.Query, Description="filter by name/netid, ex: `Ron` or `rswanso`")]
-        [OpenApiParameter("_limit", In=ParameterLocation.Query, Description="Restrict the number of responses to no more than this integer.  ex: `15` or `20`")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
+        [OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by name/netid, ex: `Ron` or `rswanso`")]
+        [OpenApiParameter("_limit", In = ParameterLocation.Query, Description = "Restrict the number of responses to no more than this integer.  ex: `15` or `20`")]
         public static Task<IActionResult> PeopleLookup(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people-lookup")] HttpRequest req) 
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "people-lookup")] HttpRequest req)
             => Security.Authenticate(req)
                 .Bind(_ => HrPeopleSearchParameters.Parse(req))
                 .Bind(query => Request.ValidateBody(query)) //Validate query params

--- a/src/API/Functions/SupportRelationships.cs
+++ b/src/API/Functions/SupportRelationships.cs
@@ -16,89 +16,95 @@ using System.Net.Mime;
 
 namespace API.Functions
 {
-	public static class SupportRelationships
-	{
-		public const string SupportRelationshipsTitle = "Support Relationships";
+    public static class SupportRelationships
+    {
+        public const string SupportRelationshipsTitle = "Support Relationships";
 
-		public const string CombinedCreateUpdateError = "The request body was malformed, the unitId, departmentId, and/or supportTypeId field was missing or invalid.\\\n**or**\\\nThe request body was malformed, the provided unit has been archived and is not available for new Support Relationships.";
-		
-		
+        public const string CombinedCreateUpdateError = "The request body was malformed, the unitId, departmentId, and/or supportTypeId field was missing or invalid.\\\n**or**\\\nThe request body was malformed, the provided unit has been archived and is not available for new Support Relationships.";
 
-		[FunctionName(nameof(SupportRelationships.SupportRelationshipsGetAll))]
-		[OpenApiOperation(nameof(SupportRelationships.SupportRelationshipsGetAll), SupportRelationshipsTitle, Summary = "List all unit-department support relationships")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SupportRelationshipResponse>), Description = "A collection of department support relationship records")]
-		public static Task<IActionResult> SupportRelationshipsGetAll(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "supportRelationships")] HttpRequest req)
-			=> Security.Authenticate(req)
-				.Bind(query => SupportRelationshipsRepository.GetAll())
-				.Bind(sr => Pipeline.Success(SupportRelationshipResponse.ConvertList(sr)))
-				.Finally(results => Response.Ok(req, results));
+        [FunctionName(nameof(SupportRelationships.SupportRelationshipsGetAll))]
+        [OpenApiOperation(nameof(SupportRelationships.SupportRelationshipsGetAll), SupportRelationshipsTitle, Summary = "List all unit-department support relationships")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SupportRelationshipResponse>), Description = "A collection of department support relationship records")]
+        public static Task<IActionResult> SupportRelationshipsGetAll(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "supportRelationships")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(query => SupportRelationshipsRepository.GetAll())
+                .Bind(sr => Pipeline.Success(SupportRelationshipResponse.ConvertList(sr)))
+                .Finally(results => Response.Ok(req, results));
 
-		[FunctionName(nameof(SupportRelationships.SupportRelationshipsGetOne))]
-		[OpenApiOperation(nameof(SupportRelationships.SupportRelationshipsGetOne), SupportRelationshipsTitle, Summary = "Find a unit-department support relationships by ID")]
-		[OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department support relationship record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(SupportRelationshipResponse), Description = "A department support relationship record")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department support relationship was found with the ID provided.")]
-		public static Task<IActionResult> SupportRelationshipsGetOne(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "supportRelationships/{relationshipId}")] HttpRequest req, int relationshipId)
-			=> Security.Authenticate(req)
-				.Bind(_ => SupportRelationshipsRepository.GetOne(relationshipId))
-				.Bind(sr => Pipeline.Success(new SupportRelationshipResponse(sr)))
-				.Finally(result => Response.Ok(req, result));
+        [FunctionName(nameof(SupportRelationships.SupportRelationshipsGetOne))]
+        [OpenApiOperation(nameof(SupportRelationships.SupportRelationshipsGetOne), SupportRelationshipsTitle, Summary = "Find a unit-department support relationships by ID")]
+        [OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department support relationship record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(SupportRelationshipResponse), Description = "A department support relationship record")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department support relationship was found with the ID provided.")]
+        public static Task<IActionResult> SupportRelationshipsGetOne(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "supportRelationships/{relationshipId}")] HttpRequest req, string relationshipId)
+            => Utils.ConvertParam(relationshipId, nameof(relationshipId))
+                .Bind(id => SupportRelationshipsGetOneInternal(req, id))
+                .Bind(sr => Pipeline.Success(new SupportRelationshipResponse(sr)))
+                .Finally(result => Response.Ok(req, result));
 
-		[FunctionName(nameof(SupportRelationships.CreateSupportRelationship))]
-		[OpenApiOperation(nameof(SupportRelationships.CreateSupportRelationship), SupportRelationshipsTitle, Summary = "Create a unit-department support relationship", Description = "Authorization: Support relationships can be created by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(SupportRelationshipRequest), Required = true)]
-		[OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(SupportRelationshipResponse), Description = "The newly created department support relationship record")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = CombinedCreateUpdateError)]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified unit, department, and/or support type does not exist.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided unit already has a support relationship with the provided department.")]
+        private static Task<Result<SupportRelationship, Error>> SupportRelationshipsGetOneInternal(HttpRequest req, int relationshipId)
+            => Security.Authenticate(req)
+                .Bind(_ => SupportRelationshipsRepository.GetOne(relationshipId));
 
-		public static Task<IActionResult> CreateSupportRelationship(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "supportRelationships")] HttpRequest req)
-		{
-			string requestorNetId = null;
-			SupportRelationshipRequest supportRelationshipRequest = null;
-			return Security.Authenticate(req)
-			.Tap(requestor => requestorNetId = requestor)
-			.Bind(requestor => Request.DeserializeBody<SupportRelationshipRequest>(req))
-			.Tap(srr => supportRelationshipRequest = srr)
-			.Bind(srr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, srr.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
-			.Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
-			.Bind(authorized => SupportRelationshipsRepository.CreateSupportRelationship(supportRelationshipRequest))
-			.Bind(sr => Pipeline.Success(new SupportRelationshipResponse(sr)))
-			.Finally(result => Response.Created(req, result));
-		}
+        [FunctionName(nameof(SupportRelationships.CreateSupportRelationship))]
+        [OpenApiOperation(nameof(SupportRelationships.CreateSupportRelationship), SupportRelationshipsTitle, Summary = "Create a unit-department support relationship", Description = "Authorization: Support relationships can be created by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(SupportRelationshipRequest), Required = true)]
+        [OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(SupportRelationshipResponse), Description = "The newly created department support relationship record")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = CombinedCreateUpdateError)]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified unit, department, and/or support type does not exist.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided unit already has a support relationship with the provided department.")]
 
-		[FunctionName(nameof(SupportRelationships.DeleteSupportRelationship))]
-		[OpenApiOperation(nameof(SupportRelationships.DeleteSupportRelationship), SupportRelationshipsTitle, Summary = "Delete a unit-department support relationship", Description = "Authorization: Support relationships can be deleted by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department support relationship record.")]
-		[OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department support relationship was found with the ID provided.")]
-		public static Task<IActionResult> DeleteSupportRelationship(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "supportRelationships/{relationshipId}")] HttpRequest req, int relationshipId)
-		{
-			string requestorNetId = null;
-			return Security.Authenticate(req)
-				.Tap(requestor => requestorNetId = requestor)
-				.Bind(requestor => SupportRelationshipsRepository.GetOne(relationshipId))
-				.Bind(sr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, sr.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
-				.Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
-				.Bind(_ => SupportRelationshipsRepository.DeleteSupportRelationship(req, relationshipId))
-				.Finally(result => Response.NoContent(req, result));
-		}
+        public static Task<IActionResult> CreateSupportRelationship(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "supportRelationships")] HttpRequest req)
+        {
+            string requestorNetId = null;
+            SupportRelationshipRequest supportRelationshipRequest = null;
+            return Security.Authenticate(req)
+            .Tap(requestor => requestorNetId = requestor)
+            .Bind(requestor => Request.DeserializeBody<SupportRelationshipRequest>(req))
+            .Tap(srr => supportRelationshipRequest = srr)
+            .Bind(srr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, srr.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
+            .Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
+            .Bind(authorized => SupportRelationshipsRepository.CreateSupportRelationship(supportRelationshipRequest))
+            .Bind(sr => Pipeline.Success(new SupportRelationshipResponse(sr)))
+            .Finally(result => Response.Created(req, result));
+        }
 
-		[FunctionName(nameof(SupportRelationships.SsspSupportRelationships))]
-		[OpenApiOperation(nameof(SupportRelationships.SsspSupportRelationships), SupportRelationshipsTitle, Summary = "Lists Support Relationships using a query specifically for SSSP's use.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SsspSupportRelationshipResponse>), Description = "A collection of department support relationship records")]
-		[OpenApiParameter("dept", In=ParameterLocation.Query, Description="Filter results by the department's name. The provided value must exactly match the department's name.")]
-		public static Task<IActionResult> SsspSupportRelationships(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "SsspSupportRelationships")] HttpRequest req)
-			=> Security.Authenticate(req)
-				.Bind(_ => SsspSupportRelationshipParameters.Parse(req))
-				.Bind(query => SupportRelationshipsRepository.GetSssp(query))
-				.Finally(results => Response.Ok(req, results));
-	}
+        [FunctionName(nameof(SupportRelationships.DeleteSupportRelationship))]
+        [OpenApiOperation(nameof(SupportRelationships.DeleteSupportRelationship), SupportRelationshipsTitle, Summary = "Delete a unit-department support relationship", Description = "Authorization: Support relationships can be deleted by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiParameter("relationshipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the department support relationship record.")]
+        [OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No department support relationship was found with the ID provided.")]
+        public static Task<IActionResult> DeleteSupportRelationship(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "supportRelationships/{relationshipId}")] HttpRequest req, string relationshipId)
+            => Utils.ConvertParam(relationshipId, nameof(relationshipId))
+                .Bind(id => DeleteSupportRelationshipInternal(req, id))
+                .Finally(result => Response.NoContent(req, result));
+
+        private static Task<Result<bool, Error>> DeleteSupportRelationshipInternal(HttpRequest req, int relationshipId)
+        {
+            string requestorNetId = null;
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(requestor => SupportRelationshipsRepository.GetOne(relationshipId))
+                .Bind(sr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, sr.UnitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
+                .Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
+                .Bind(_ => SupportRelationshipsRepository.DeleteSupportRelationship(req, relationshipId));
+        }
+
+        [FunctionName(nameof(SupportRelationships.SsspSupportRelationships))]
+        [OpenApiOperation(nameof(SupportRelationships.SsspSupportRelationships), SupportRelationshipsTitle, Summary = "Lists Support Relationships using a query specifically for SSSP's use.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SsspSupportRelationshipResponse>), Description = "A collection of department support relationship records")]
+        [OpenApiParameter("dept", In = ParameterLocation.Query, Description = "Filter results by the department's name. The provided value must exactly match the department's name.")]
+        public static Task<IActionResult> SsspSupportRelationships(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "SsspSupportRelationships")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(_ => SsspSupportRelationshipParameters.Parse(req))
+                .Bind(query => SupportRelationshipsRepository.GetSssp(query))
+                .Finally(results => Response.Ok(req, results));
+    }
 }

--- a/src/API/Functions/UnitMemberTools.cs
+++ b/src/API/Functions/UnitMemberTools.cs
@@ -15,105 +15,120 @@ using Models;
 
 namespace API.Functions
 {
-	public static class UnitMemberTools
-	{
-		public const string Title = "Unit Member Tools";
-		public const string CombinedError = UnitMemberToolsRepository.MalformedBody + "\\\n**or**\\\n" + UnitMemberToolsRepository.ArchivedUnit;
+    public static class UnitMemberTools
+    {
+        public const string Title = "Unit Member Tools";
+        public const string CombinedError = UnitMemberToolsRepository.MalformedBody + "\\\n**or**\\\n" + UnitMemberToolsRepository.ArchivedUnit;
 
-		[FunctionName(nameof(UnitMemberTools.UnitMemberToolsGetAll))]
-		[OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsGetAll), Title, Summary = "List all unit member tools")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<MemberToolResponse>), Description = "A collection of unit member tool records")]
-		public static Task<IActionResult> UnitMemberToolsGetAll(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "membertools")] HttpRequest req)
-			=> Security.Authenticate(req)
-				.Bind(query => UnitMemberToolsRepository.GetAll())
-				.Bind(mt => Pipeline.Success(MemberToolResponse.ConvertList(mt)))
-				.Finally(results => Response.Ok(req, results));
+        [FunctionName(nameof(UnitMemberTools.UnitMemberToolsGetAll))]
+        [OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsGetAll), Title, Summary = "List all unit member tools")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<MemberToolResponse>), Description = "A collection of unit member tool records")]
+        public static Task<IActionResult> UnitMemberToolsGetAll(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "membertools")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(query => UnitMemberToolsRepository.GetAll())
+                .Bind(mt => Pipeline.Success(MemberToolResponse.ConvertList(mt)))
+                .Finally(results => Response.Ok(req, results));
 
-		[FunctionName(nameof(UnitMemberTools.UnitMemberToolsGetOne))]
-		[OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsGetOne), Title, Summary = "Find a unit member tool by ID")]
-		[OpenApiParameter("memberToolId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit member tool record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(MemberToolResponse), Description = "A unit member tool record")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No member tool record was found with the ID provided.")]
-		public static Task<IActionResult> UnitMemberToolsGetOne(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "membertools/{memberToolId}")] HttpRequest req, int memberToolId)
-		{
-			string requestorNetId = null;
-			MemberTool memberTool = null;
-			return Security.Authenticate(req) 
-				.Tap(requestor => requestorNetId = requestor)
-				.Bind(_ => UnitMemberToolsRepository.GetOne(memberToolId))
-				.Tap(mt => memberTool = mt)			
-				.Bind(mt => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mt.MembershipId))
-				.Bind(_ => Pipeline.Success(memberTool.ToMemberToolResponse()))
-				.Finally(result => Response.Ok(req, result));
-		}
+        [FunctionName(nameof(UnitMemberTools.UnitMemberToolsGetOne))]
+        [OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsGetOne), Title, Summary = "Find a unit member tool by ID")]
+        [OpenApiParameter("memberToolId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit member tool record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(MemberToolResponse), Description = "A unit member tool record")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No member tool record was found with the ID provided.")]
+        public static Task<IActionResult> UnitMemberToolsGetOne(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "membertools/{memberToolId}")] HttpRequest req, string memberToolId)
+            => Utils.ConvertParam(memberToolId, nameof(memberToolId))
+            .Bind(id => UnitMemberToolsGetOneInternal(req, id))
+            .Finally(result => Response.Ok(req, result));
 
-		[FunctionName(nameof(UnitMemberTools.UnitMemberToolsCreate))]
-		[OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsCreate), Title, Summary = "Create a unit member tool.", Description = "*Authorization*: Unit tool permissions can be created by any unit member that has either the `Owner` or `ManageTools` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitMembersGetAll).")]
-		[OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(MemberToolRequest), Required = true)]
-		[OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(MemberToolResponse), Description = "The newly created unit member tool record")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = CombinedError)]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified tool does not exist. **or** The specified member does not exist.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = UnitMemberToolsRepository.MemberToolConflict)]
-		public static Task<IActionResult> UnitMemberToolsCreate([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "membertools")] HttpRequest req)
-		{
-			string requestorNetId = null;
-			MemberToolRequest memberToolRequest = null;
-			return Security.Authenticate(req)
-			.Tap(requestor => requestorNetId = requestor)
-			.Bind(requestor => Request.DeserializeBody<MemberToolRequest>(req))
-			.Tap(mtr => memberToolRequest = mtr)
-			.Bind(mtr => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mtr.MembershipId))// Set headers saying what the requestor can do based on the MemberTool's UnitMember.Unit
-			.Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
-			.Bind(authorized => UnitMemberToolsRepository.CreateUnitMemberTool(memberToolRequest))
-			.Bind(mt => Pipeline.Success(mt.ToMemberToolResponse()))
-			.Finally(result => Response.Created(req, result));
-		}
+        private static Task<Result<MemberToolResponse, Error>> UnitMemberToolsGetOneInternal(HttpRequest req, int memberToolId)
+        {
+            string requestorNetId = null;
+            MemberTool memberTool = null;
 
-		[FunctionName(nameof(UnitMemberTools.UnitMemberToolsUpdate))]
-		[OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsUpdate), Title, Summary = "Update a unit member tool", Description = "*Authorization*: Unit tool permissions can be updated by any unit member that has either the `Owner` or `ManageTools` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitMembersGetAll).")]
-		[OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(MemberToolRequest), Required = true)]
-		[OpenApiParameter("memberToolId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit member tool record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(MemberToolResponse), Description = "The updated unt member tool record")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = CombinedError)]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified tool does not exist. **or** The specified member does not exist.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = UnitMemberToolsRepository.MemberToolConflict)]
-		public static Task<IActionResult> UnitMemberToolsUpdate(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "membertools/{memberToolId}")] HttpRequest req, int memberToolId)
-		{
-			string requestorNetId = null;
-			MemberToolRequest memberToolRequest = null;
-			return Security.Authenticate(req)
-				.Tap(requestor => requestorNetId = requestor)
-				.Bind(requestor => Request.DeserializeBody<MemberToolRequest>(req))
-				.Tap(mtr => memberToolRequest = mtr)
-				.Bind(mtr => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mtr.MembershipId))// Set headers saying what the requestor can do based on the MemberTool's UnitMember.Unit
-				.Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
-				.Bind(authorized => UnitMemberToolsRepository.UpdateUnitMemberTool(req, memberToolRequest, memberToolId))
-				.Bind(mr => Pipeline.Success(mr.ToMemberToolResponse()))
-				.Finally(result => Response.Ok(req, result));
-		}
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(_ => UnitMemberToolsRepository.GetOne(memberToolId))
+                .Tap(mt => memberTool = mt)
+                .Bind(mt => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mt.MembershipId))
+                .Bind(_ => Pipeline.Success(memberTool.ToMemberToolResponse()));
+        }
 
-		[FunctionName(nameof(UnitMemberTools.UnitMemberToolDelete))]
-		[OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolDelete), Title, Summary = "Delete a unit member tool", Description = "*Authorization*: Unit tool permissions can be deleted by any unit member that has either the `Owner` or `ManageTools` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitMembersGetAll).")]
-		[OpenApiParameter("memberToolId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit member tool record.")]
-		[OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit member tool was found with the ID provided.")]
-		public static Task<IActionResult> UnitMemberToolDelete(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "membertools/{memberToolId}")] HttpRequest req, int memberToolId)
-		{
-			string requestorNetId = null;
-			return Security.Authenticate(req)
-				.Tap(requestor => requestorNetId = requestor)
-				.Bind(requestor => UnitMemberToolsRepository.GetOne(memberToolId))
-				.Bind(mt => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mt.MembershipId))// Set headers saying what the requestor can do based on the MemberTool's UnitMember.Unit
-				.Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
-				.Bind(_ => UnitMemberToolsRepository.DeleteUnitMemberTool(req, memberToolId))
-				.Finally(result => Response.NoContent(req, result));
-		}
-	}
+        [FunctionName(nameof(UnitMemberTools.UnitMemberToolsCreate))]
+        [OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsCreate), Title, Summary = "Create a unit member tool.", Description = "*Authorization*: Unit tool permissions can be created by any unit member that has either the `Owner` or `ManageTools` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitMembersGetAll).")]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(MemberToolRequest), Required = true)]
+        [OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(MemberToolResponse), Description = "The newly created unit member tool record")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = CombinedError)]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified tool does not exist. **or** The specified member does not exist.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = UnitMemberToolsRepository.MemberToolConflict)]
+        public static Task<IActionResult> UnitMemberToolsCreate([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "membertools")] HttpRequest req)
+        {
+            string requestorNetId = null;
+            MemberToolRequest memberToolRequest = null;
+            return Security.Authenticate(req)
+            .Tap(requestor => requestorNetId = requestor)
+            .Bind(requestor => Request.DeserializeBody<MemberToolRequest>(req))
+            .Tap(mtr => memberToolRequest = mtr)
+            .Bind(mtr => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mtr.MembershipId))// Set headers saying what the requestor can do based on the MemberTool's UnitMember.Unit
+            .Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
+            .Bind(authorized => UnitMemberToolsRepository.CreateUnitMemberTool(memberToolRequest))
+            .Bind(mt => Pipeline.Success(mt.ToMemberToolResponse()))
+            .Finally(result => Response.Created(req, result));
+        }
+
+        [FunctionName(nameof(UnitMemberTools.UnitMemberToolsUpdate))]
+        [OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolsUpdate), Title, Summary = "Update a unit member tool", Description = "*Authorization*: Unit tool permissions can be updated by any unit member that has either the `Owner` or `ManageTools` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitMembersGetAll).")]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(MemberToolRequest), Required = true)]
+        [OpenApiParameter("memberToolId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit member tool record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(MemberToolResponse), Description = "The updated unt member tool record")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = CombinedError)]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified tool does not exist. **or** The specified member does not exist.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = UnitMemberToolsRepository.MemberToolConflict)]
+        public static Task<IActionResult> UnitMemberToolsUpdate(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "membertools/{memberToolId}")] HttpRequest req, string memberToolId)
+            => Utils.ConvertParam(memberToolId, nameof(memberToolId))
+                .Bind(id => UnitMemberToolsUpdateInternal(req, id))
+                .Bind(mr => Pipeline.Success(mr.ToMemberToolResponse()))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<MemberTool, Error>> UnitMemberToolsUpdateInternal(HttpRequest req, int memberToolId)
+        {
+            string requestorNetId = null;
+            MemberToolRequest memberToolRequest = null;
+
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(requestor => Request.DeserializeBody<MemberToolRequest>(req))
+                .Tap(mtr => memberToolRequest = mtr)
+                .Bind(mtr => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mtr.MembershipId))// Set headers saying what the requestor can do based on the MemberTool's UnitMember.Unit
+                .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
+                .Bind(authorized => UnitMemberToolsRepository.UpdateUnitMemberTool(req, memberToolRequest, memberToolId));
+        }
+
+        [FunctionName(nameof(UnitMemberTools.UnitMemberToolDelete))]
+        [OpenApiOperation(nameof(UnitMemberTools.UnitMemberToolDelete), Title, Summary = "Delete a unit member tool", Description = "*Authorization*: Unit tool permissions can be deleted by any unit member that has either the `Owner` or `ManageTools` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitMembersGetAll).")]
+        [OpenApiParameter("memberToolId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit member tool record.")]
+        [OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit member tool was found with the ID provided.")]
+        public static Task<IActionResult> UnitMemberToolDelete(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "membertools/{memberToolId}")] HttpRequest req, string memberToolId)
+            => Utils.ConvertParam(memberToolId, nameof(memberToolId))
+            .Bind(id => UnitMemberToolDeleteInternal(req, id))
+            .Finally(result => Response.NoContent(req, result));
+
+        private static Task<Result<bool, Error>> UnitMemberToolDeleteInternal(HttpRequest req, int memberToolId)
+        {
+            string requestorNetId = null;
+
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(requestor => UnitMemberToolsRepository.GetOne(memberToolId))
+                .Bind(mt => AuthorizationRepository.DetermineUnitMemberToolPermissions(req, requestorNetId, mt.MembershipId))// Set headers saying what the requestor can do based on the MemberTool's UnitMember.Unit
+                .Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
+                .Bind(_ => UnitMemberToolsRepository.DeleteUnitMemberTool(req, memberToolId));
+        }
+    }
 }

--- a/src/API/Functions/UnitMembers.cs
+++ b/src/API/Functions/UnitMembers.cs
@@ -15,110 +15,124 @@ using Microsoft.OpenApi.Models;
 using System.Net.Mime;
 using System.Linq;
 using Models.Enums;
+using static Models.TestEntities;
 
 namespace API.Functions
 {
-	public static class UnitMembers
-	{
-		public const string UnitMembersTitle = "Unit Memberships";
-		public const string PostPutBadResponseDescription = "The request body was malformed or the unitId field was missing.\\\n**or**\\\nThe field Percentage must be between 0 and 100.\\\n**or**\\\nThe provided unit has been archived and is not available for new Unit Members.";
+    public static class UnitMembers
+    {
+        public const string UnitMembersTitle = "Unit Memberships";
+        public const string PostPutBadResponseDescription = "The request body was malformed or the unitId field was missing.\\\n**or**\\\nThe field Percentage must be between 0 and 100.\\\n**or**\\\nThe provided unit has been archived and is not available for new Unit Members.";
 
 
-		[FunctionName(nameof(UnitMembers.UnitMembersGetAll))]
-		[OpenApiOperation(nameof(UnitMembers.UnitMembersGetAll), UnitMembersTitle, Summary = "List all unit memberships")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<UnitMemberResponse>), Description = "A collection of unit membership record")]
-		public static Task<IActionResult> UnitMembersGetAll(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "memberships")] HttpRequest req)
-			=> Security.Authenticate(req)
-				.Bind(_ => UnitMembersRepository.GetAll())
-				.Bind(res => Pipeline.Success(res.Where(e => e.Unit.Active).Select(e => e.ToUnitMemberResponse(EntityPermissions.Get))))
-				.Finally(dtos => Response.Ok(req, dtos));
+        [FunctionName(nameof(UnitMembers.UnitMembersGetAll))]
+        [OpenApiOperation(nameof(UnitMembers.UnitMembersGetAll), UnitMembersTitle, Summary = "List all unit memberships")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<UnitMemberResponse>), Description = "A collection of unit membership record")]
+        public static Task<IActionResult> UnitMembersGetAll(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "memberships")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(_ => UnitMembersRepository.GetAll())
+                .Bind(res => Pipeline.Success(res.Where(e => e.Unit.Active).Select(e => e.ToUnitMemberResponse(EntityPermissions.Get))))
+                .Finally(dtos => Response.Ok(req, dtos));
 
-		[FunctionName(nameof(UnitMembers.UnitMembersGetOne))]
-		[OpenApiOperation(nameof(UnitMembers.UnitMembersGetOne), UnitMembersTitle, Summary = "Find a unit membership by ID")]
-		[OpenApiParameter("membershipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit membership record.")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(UnitMemberResponse), Description = "A unit membership record")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit membership was found with the ID provided.")]
-		public static Task<IActionResult> UnitMembersGetOne(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "memberships/{membershipId}")] HttpRequest req, int membershipId)
-		{
-			string requestorNetId = null;
-			UnitMember unitMember = null;
-			return Security.Authenticate(req)
-			.Tap(requestor => requestorNetId = requestor)
-			.Bind(_ => UnitMembersRepository.GetOne(membershipId))
-			.Tap(um => unitMember = um)
-			.Bind(um => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, um.UnitId))
-			.Bind(perms => Pipeline.Success(unitMember.ToUnitMemberResponse(perms)))
-			.Finally(result => Response.Ok(req, result));
-		}
+        [FunctionName(nameof(UnitMembers.UnitMembersGetOne))]
+        [OpenApiOperation(nameof(UnitMembers.UnitMembersGetOne), UnitMembersTitle, Summary = "Find a unit membership by ID")]
+        [OpenApiParameter("membershipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit membership record.")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(UnitMemberResponse), Description = "A unit membership record")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit membership was found with the ID provided.")]
+        public static Task<IActionResult> UnitMembersGetOne(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "memberships/{membershipId}")] HttpRequest req, string membershipId)
+                => Utils.ConvertParam(membershipId, nameof(membershipId))
+                .Bind(id => UnitMembersGetOneInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
 
-		[FunctionName(nameof(UnitMembers.CreateUnitMembers))]
-		[OpenApiOperation(nameof(UnitMembers.CreateUnitMembers), UnitMembersTitle, Summary = "Create a unit membership", Description = "Authorization: Unit memberships can be created by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitMemberRequest), Required = true)]
-		[OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(UnitMemberResponse), Description = "The newly created unit membership record")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = PostPutBadResponseDescription)]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to modify this unit.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified unit and/or person does not exist.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided person is already a member of the provided unit.")]
-		public static Task<IActionResult> CreateUnitMembers(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "memberships")] HttpRequest req)
-		{
-			string requestorNetId = null;
-			UnitMemberRequest unitMemberRequest = null;
-			return Security.Authenticate(req)
-			.Tap(requestor => requestorNetId = requestor)
-			.Bind(requestor => Request.DeserializeBody<UnitMemberRequest>(req))
-			.Tap(umr => unitMemberRequest = umr)
-			.Bind(umr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, umr.UnitId))// Set headers saying what the requestor can do to this unit
-			.Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
-			.Bind(authorized => UnitMembersRepository.CreateMembership(unitMemberRequest))
-			.Bind(res => Pipeline.Success(res.ToUnitMemberResponse(EntityPermissions.Post)))
-			.Finally(result => Response.Created(req, result));
-		}
+        private static Task<Result<UnitMemberResponse, Error>> UnitMembersGetOneInternal(HttpRequest req, int membershipId)
+        {
+            string requestorNetId = null;
+            UnitMember unitMember = null;
 
-		[FunctionName(nameof(UnitMembers.UpdateUnitMember))]
-		[OpenApiOperation(nameof(UnitMembers.UpdateUnitMember), UnitMembersTitle, Summary = "Update a unit membership.", Description = "Authorization: Unit memberships can be modified by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitMemberRequest), Required = true)]
-		[OpenApiParameter("membershipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit membership record")]
-		[OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(UnitMemberResponse), Description = "The updated unit membership record")]
-		[OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = PostPutBadResponseDescription)]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No membership was found with the ID provided or the specified unit and/or person does not exist.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided person is already a member of the provided unit.")]
-		public static Task<IActionResult> UpdateUnitMember(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "memberships/{membershipId}")] HttpRequest req, int membershipId)
-		{
-			string requestorNetId = null;
-			UnitMemberRequest unitMemberRequest = null;
-			return Security.Authenticate(req)
-				.Tap(requestor => requestorNetId = requestor)
-				.Bind(requestor => Request.DeserializeBody<UnitMemberRequest>(req))
-				.Tap(umr => unitMemberRequest = umr)
-				.Bind(umr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, umr.UnitId))// Set headers saying what the requestor can do to this unit
-				.Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
-				.Bind(authorized => UnitMembersRepository.UpdateMembership(req, unitMemberRequest, membershipId))
-				.Bind(um => Pipeline.Success(um.ToUnitMemberResponse(EntityPermissions.Put)))
-				.Finally(result => Response.Ok(req, result));
-		}
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(_ => UnitMembersRepository.GetOne(membershipId))
+                .Tap(um => unitMember = um)
+                .Bind(um => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, um.UnitId))
+                .Bind(perms => Pipeline.Success(unitMember.ToUnitMemberResponse(perms)));
+        }
 
-		[FunctionName(nameof(UnitMembers.DeleteUnitMembership))]
-		[OpenApiOperation(nameof(UnitMembers.DeleteUnitMembership), UnitMembersTitle, Summary = "Delete a unit membership", Description = "Authorization: Unit memberships can be deleted by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-		[OpenApiParameter("membershipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit membership record.")]
-		[OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
-		[OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
-		[OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No membership was found with the ID provided.")]
-		public static Task<IActionResult> DeleteUnitMembership(
-			[HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "memberships/{membershipId}")] HttpRequest req, int membershipId)
-		{
-			string requestorNetId = null;
-			return Security.Authenticate(req)
-				.Tap(requestor => requestorNetId = requestor)
-				.Bind(requestor => UnitMembersRepository.GetOne(membershipId))
-				.Bind(um => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, um.UnitId))// Set headers saying what the requestor can do to this unit
-				.Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
-				.Bind(_ => UnitMembersRepository.DeleteMembership(req, membershipId))
-				.Finally(result => Response.NoContent(req, result));
-		}
-	}
+        [FunctionName(nameof(UnitMembers.CreateUnitMembers))]
+        [OpenApiOperation(nameof(UnitMembers.CreateUnitMembers), UnitMembersTitle, Summary = "Create a unit membership", Description = "Authorization: Unit memberships can be created by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitMemberRequest), Required = true)]
+        [OpenApiResponseWithBody(HttpStatusCode.Created, MediaTypeNames.Application.Json, typeof(UnitMemberResponse), Description = "The newly created unit membership record")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = PostPutBadResponseDescription)]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to modify this unit.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The specified unit and/or person does not exist.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided person is already a member of the provided unit.")]
+        public static Task<IActionResult> CreateUnitMembers(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "memberships")] HttpRequest req)
+        {
+            string requestorNetId = null;
+            UnitMemberRequest unitMemberRequest = null;
+            return Security.Authenticate(req)
+            .Tap(requestor => requestorNetId = requestor)
+            .Bind(requestor => Request.DeserializeBody<UnitMemberRequest>(req))
+            .Tap(umr => unitMemberRequest = umr)
+            .Bind(umr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, umr.UnitId))// Set headers saying what the requestor can do to this unit
+            .Bind(perms => AuthorizationRepository.AuthorizeCreation(perms))
+            .Bind(authorized => UnitMembersRepository.CreateMembership(unitMemberRequest))
+            .Bind(res => Pipeline.Success(res.ToUnitMemberResponse(EntityPermissions.Post)))
+            .Finally(result => Response.Created(req, result));
+        }
+
+        [FunctionName(nameof(UnitMembers.UpdateUnitMember))]
+        [OpenApiOperation(nameof(UnitMembers.UpdateUnitMember), UnitMembersTitle, Summary = "Update a unit membership.", Description = "Authorization: Unit memberships can be modified by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitMemberRequest), Required = true)]
+        [OpenApiParameter("membershipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit membership record")]
+        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(UnitMemberResponse), Description = "The updated unit membership record")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = PostPutBadResponseDescription)]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No membership was found with the ID provided or the specified unit and/or person does not exist.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The provided person is already a member of the provided unit.")]
+        public static Task<IActionResult> UpdateUnitMember(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "memberships/{membershipId}")] HttpRequest req, string membershipId)
+            => Utils.ConvertParam(membershipId, nameof(membershipId))
+            .Bind(id => UpdateUnitMemberInternal(req, id)).Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<UnitMemberResponse, Error>> UpdateUnitMemberInternal(HttpRequest req, int membershipId)
+        {
+            string requestorNetId = null;
+            UnitMemberRequest unitMemberRequest = null;
+
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(requestor => Request.DeserializeBody<UnitMemberRequest>(req))
+                .Tap(umr => unitMemberRequest = umr)
+                .Bind(umr => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, umr.UnitId))// Set headers saying what the requestor can do to this unit
+                .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
+                .Bind(authorized => UnitMembersRepository.UpdateMembership(req, unitMemberRequest, membershipId))
+                .Bind(um => Pipeline.Success(um.ToUnitMemberResponse(EntityPermissions.Put)));
+        }
+
+        [FunctionName(nameof(UnitMembers.DeleteUnitMembership))]
+        [OpenApiOperation(nameof(UnitMembers.DeleteUnitMembership), UnitMembersTitle, Summary = "Delete a unit membership", Description = "Authorization: Unit memberships can be deleted by any unit member that has either the `Owner` or `ManageMembers` permission on their unit membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
+        [OpenApiParameter("membershipId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit membership record.")]
+        [OpenApiResponseWithoutBody(HttpStatusCode.NoContent, Description = "Success.")]
+        [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You are not authorized to make this request.")]
+        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No membership was found with the ID provided.")]
+        public static Task<IActionResult> DeleteUnitMembership(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "memberships/{membershipId}")] HttpRequest req, string membershipId)
+            => Utils.ConvertParam(membershipId, nameof(membershipId))
+            .Bind(id => DeleteUnitMemberInternal(req, id))
+            .Finally(result => Response.NoContent(req, result));
+
+        private static Task<Result<bool, Error>> DeleteUnitMemberInternal(HttpRequest req, int membershipId)
+        {
+            string requestorNetId = null;
+            return Security.Authenticate(req)
+                .Tap(requestor => requestorNetId = requestor)
+                .Bind(requestor => UnitMembersRepository.GetOne(membershipId))
+                .Bind(um => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestorNetId, um.UnitId))// Set headers saying what the requestor can do to this unit
+                .Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
+                .Bind(_ => UnitMembersRepository.DeleteMembership(req, membershipId));
+        }
+    }
 }

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -74,13 +74,16 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You do not have permission to modify this unit.")]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = NotFoundError)]
         public static Task<IActionResult> UpdateUnit(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "units/{unitId}")] HttpRequest req, int unitId)
-            => Security.Authenticate(req)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "units/{unitId}")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => UpdateUnitInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<Unit, Error>> UpdateUnitInternal(HttpRequest req, int unitId) => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
                 .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
                 .Bind(_ => Request.DeserializeBody<UnitRequest>(req))
-                .Bind(body => UnitsRepository.UpdateUnit(req, body, unitId))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(body => UnitsRepository.UpdateUnit(req, body, unitId));
 
         [FunctionName(nameof(Units.DeleteUnit))]
         [OpenApiOperation(nameof(Units.DeleteUnit), nameof(Units), Summary = "Delete a unit", Description = "_Authorization_: Unit deletion is restricted to service administrators.")]

--- a/src/API/Functions/Units.cs
+++ b/src/API/Functions/Units.cs
@@ -2,7 +2,6 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
-
 using API.Data;
 using API.Middleware;
 using Microsoft.AspNetCore.Mvc;
@@ -15,7 +14,6 @@ using Microsoft.OpenApi.Models;
 using System.Net.Mime;
 using System.Linq;
 using Models.Enums;
-using System.Net.Http;
 
 namespace API.Functions
 {
@@ -24,10 +22,10 @@ namespace API.Functions
         private const string NotFoundError = "No unit found with ID (`unitId`).\\\n **or**\\\n No parent unit found with ID (`parentId`).";
 
         [FunctionName(nameof(Units.UnitsGetAll))]
-        [OpenApiOperation(nameof(Units.UnitsGetAll), nameof(Units), Summary="List all IT units", Description = @"Search for IT units by name and/or description. If no search term is provided, lists all top-level IT units." )]
+        [OpenApiOperation(nameof(Units.UnitsGetAll), nameof(Units), Summary = "List all IT units", Description = @"Search for IT units by name and/or description. If no search term is provided, lists all top-level IT units.")]
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<UnitResponse>))]
-        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description="The search query was malformed or incorrect. See response content for additional information.")]
-        [OpenApiParameter("q", In=ParameterLocation.Query, Description="filter by unit name/description, ex: `Parks`")]
+        [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = "The search query was malformed or incorrect. See response content for additional information.")]
+        [OpenApiParameter("q", In = ParameterLocation.Query, Description = "filter by unit name/description, ex: `Parks`")]
         public static Task<IActionResult> UnitsGetAll(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units")] HttpRequest req)
             => Security.Authenticate(req)
@@ -42,15 +40,19 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(UnitResponse))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> UnitsGetOne(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}")] HttpRequest req, int unitId)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => UnitsGetOneInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<Unit, Error>> UnitsGetOneInternal(HttpRequest req, int unitId)
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner, PermsGroups.GetPut))// Set headers saying what the requestor can do to this unit
-                .Bind(_ => UnitsRepository.GetOne(unitId))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(_ => UnitsRepository.GetOne(unitId));
 
         [FunctionName(nameof(Units.CreateUnit))]
         [OpenApiOperation(nameof(Units.CreateUnit), nameof(Units), Summary = "Create a unit", Description = "_Authorization_: Unit creation is restricted to service administrators.")]
-        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitRequest), Required=true)]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitRequest), Required = true)]
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(UnitResponse))]
         [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = UnitRequest.MalformedRequest)]
         [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You do not have permission to create a unit.")]
@@ -66,7 +68,7 @@ namespace API.Functions
 
         [FunctionName(nameof(Units.UpdateUnit))]
         [OpenApiOperation(nameof(Units.UpdateUnit), nameof(Units), Summary = "Update a unit", Description = "_Authorization_: Units can be modified by any unit member that has either the `Owner` or `ManageMembers` permission on their membership. See also: [Units - List all unit members](#operation/UnitsGetAll).")]
-        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitRequest), Required=true)]
+        [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(UnitRequest), Required = true)]
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(UnitResponse))]
         [OpenApiResponseWithBody(HttpStatusCode.BadRequest, MediaTypeNames.Application.Json, typeof(ApiError), Description = UnitRequest.MalformedRequest)]
         [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You do not have permission to modify this unit.")]
@@ -88,12 +90,16 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "Unit `unitId` has child units, with ids: `list of child unitIds`. These must be reassigned prior to deletion.")]
         public static Task<IActionResult> DeleteUnit(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "units/{unitId}")] HttpRequest req, int unitId)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "units/{unitId}")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => DeleteUnitInternal(req, id))
+                .Finally(result => Response.NoContent(req, result));
+
+        private static Task<Result<bool, Error>> DeleteUnitInternal(HttpRequest req, int unitId)
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineServiceAdminPermissions(req, requestor))// Set headers saying what the requestor can do to this unit
                 .Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
-                .Bind(_ => UnitsRepository.DeleteUnit(req, unitId))
-                .Finally(result => Response.NoContent(req, result));
+                .Bind(_ => UnitsRepository.DeleteUnit(req, unitId));
 
         [FunctionName(nameof(Units.ArchiveUnit))]
         [OpenApiOperation(nameof(Units.ArchiveUnit), nameof(Units), Summary = "Archive a unit", Description = "_Authorization_: Unit archival is restricted to service administrators.")]
@@ -102,12 +108,16 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.Forbidden, MediaTypeNames.Application.Json, typeof(ApiError), Description = "You do not have permission to modify this unit.")]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         [OpenApiResponseWithBody(HttpStatusCode.Conflict, MediaTypeNames.Application.Json, typeof(ApiError), Description = "Unit `unitId` has child units, with ids: `list of child unitIds`. These must be reassigned, deleted, or archived before this request can be completed.\\\n **or**\\\n Unit `unitId` has a parent unit `parentUnitId` that is archived. This parent unit must be unarchived before this request can be completed.")]
-        public static Task<IActionResult> ArchiveUnit([HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "units/{unitId}/archive")] HttpRequest req, int unitId)
+        public static Task<IActionResult> ArchiveUnit([HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "units/{unitId}/archive")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => ArchiveUnitInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<Unit, Error>> ArchiveUnitInternal(HttpRequest req, int unitId)
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineServiceAdminPermissions(req, requestor))
                 .Bind(perms => AuthorizationRepository.AuthorizeDeletion(perms))
-                .Bind(_ => UnitsRepository.ChangeActive(req, unitId))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(_ => UnitsRepository.ChangeActive(req, unitId));
 
         [FunctionName(nameof(Units.GetUnitChildren))]
         [OpenApiOperation(nameof(Units.GetUnitChildren), nameof(Units), Summary = "List all unit children ", Description = "List all units that fall below this unit in an organizational hierarchy.")]
@@ -115,11 +125,15 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<UnitResponse>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> GetUnitChildren(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/children")] HttpRequest req, int unitId)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/children")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => GetUnitChildrenInternal(req, id))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<Unit>, Error>> GetUnitChildrenInternal(HttpRequest req, int unitId)
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineServiceAdminPermissions(req, requestor))
-                .Bind(_ => UnitsRepository.GetChildren(req, unitId))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(_ => UnitsRepository.GetChildren(req, unitId));
 
         [FunctionName(nameof(Units.GetUnitMembers))]
         [OpenApiOperation(nameof(Units.GetUnitMembers), nameof(Units), Summary = "List all unit members", Description = "List all people who do IT work for this unit along with any vacant positions.")]
@@ -127,12 +141,16 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<UnitMemberResponse>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> GetUnitMembers(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/members")] HttpRequest req, int unitId)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/members")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => GetUnitMembersInternal(req, id))
+                .Bind(ms => Pipeline.Success(ms.Select(e => e.ToUnitMemberResponse(req.GetEntityPermissions()))))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<UnitMember>, Error>> GetUnitMembersInternal(HttpRequest req, int unitId)
             => Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId))// Set headers saying what the requestor can do to this unit
-                .Bind(_ => UnitsRepository.GetMembers(req, unitId))
-				.Bind(ms => Pipeline.Success(ms.Select(e => e.ToUnitMemberResponse(req.GetEntityPermissions()))))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(_ => UnitsRepository.GetMembers(req, unitId));
 
         [FunctionName(nameof(Units.GetUnitSupportedBuildings))]
         [OpenApiOperation(nameof(Units.GetUnitSupportedBuildings), nameof(Units), Summary = "List all supported buildings", Description = "List all buildings that receive IT support from this unit.")]
@@ -140,12 +158,16 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<BuildingRelationshipResponse>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> GetUnitSupportedBuildings(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/supportedBuildings")] HttpRequest req, int unitId)
-            => Security.Authenticate(req)
-                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
-                .Bind(_ => UnitsRepository.GetSupportedBuildings(req, unitId))
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/supportedBuildings")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => GetUnitSupportedBuildingsInternal(req, id))
                 .Bind(sr => Pipeline.Success(sr.Select(srx => new BuildingRelationshipResponse(srx)).ToList()))
                 .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<BuildingRelationship>, Error>> GetUnitSupportedBuildingsInternal(HttpRequest req, int unitId)
+            => Security.Authenticate(req)
+                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
+                .Bind(_ => UnitsRepository.GetSupportedBuildings(req, unitId));
 
         [FunctionName(nameof(Units.GetUnitSupportedDepartments))]
         [OpenApiOperation(nameof(Units.GetUnitSupportedDepartments), nameof(Units), Summary = "List all supported departments", Description = "List all departments that receive IT support from this unit.")]
@@ -153,12 +175,16 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<SupportRelationshipResponse>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> GetUnitSupportedDepartments(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/supportedDepartments")] HttpRequest req, int unitId)
-            => Security.Authenticate(req)
-                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
-                .Bind(_ => UnitsRepository.GetSupportedDepartments(req, unitId))
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/supportedDepartments")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+                .Bind(id => GetUnitSupportedDepartmentsInternal(req, id))
                 .Bind(sr => Pipeline.Success(sr.Select(srx => new SupportRelationshipResponse(srx)).ToList()))
                 .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<SupportRelationship>, Error>> GetUnitSupportedDepartmentsInternal(HttpRequest req, int unitId)
+            => Security.Authenticate(req)
+                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner))// Set headers saying what the requestor can do to this unit
+                .Bind(_ => UnitsRepository.GetSupportedDepartments(req, unitId));
 
         [FunctionName(nameof(Units.GetUnitTools))]
         [OpenApiOperation(nameof(Units.GetUnitTools), nameof(Units), Summary = "List all unit tools", Description = "List all tools that are available to this unit.")]
@@ -166,15 +192,20 @@ namespace API.Functions
         [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(List<ToolResponse>))]
         [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
         public static Task<IActionResult> GetUnitTools(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/tools")] HttpRequest req, int unitId)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}/tools")] HttpRequest req, string unitId)
+            => Utils.ConvertParam(unitId, nameof(unitId))
+            .Bind(id => GetUnitToolsInternal(req, id))
+                .Bind(t => Pipeline.Success(ToolResponse.ConvertList(t)))
+                .Finally(result => Response.Ok(req, result));
+
+        private static Task<Result<List<Tool>, Error>> GetUnitToolsInternal(HttpRequest req, int unitId)
         {
             string rni = null;
             return Security.Authenticate(req)
                 .Tap(requestor => rni = requestor)
-                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, new List<UnitPermissions> {UnitPermissions.ManageMembers, UnitPermissions.ManageTools}))// Set headers saying what the requestor can do to this unit
-                .Bind(_ => UnitsRepository.GetTools(req, unitId))
-                .Bind(t => Pipeline.Success(ToolResponse.ConvertList(t)))
-                .Finally(result => Response.Ok(req, result));
+                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, new List<UnitPermissions> { UnitPermissions.ManageMembers, UnitPermissions.ManageTools }))// Set headers saying what the requestor can do to this unit
+                .Bind(_ => UnitsRepository.GetTools(req, unitId));
         }
+
     }
 }

--- a/src/API/Middleware/Utils.cs
+++ b/src/API/Middleware/Utils.cs
@@ -1,4 +1,6 @@
+using CSharpFunctionalExtensions;
 using System;
+using System.Net;
 
 namespace API.Middleware
 {
@@ -12,6 +14,16 @@ namespace API.Middleware
                 throw new Exception($"Missing required environment setting: {key}");
             }
             return value;
+        }
+
+        public static Result<int, Error> ConvertParam(string value, string paramName)
+        {
+            if (!int.TryParse(value, out var result))
+            {
+                return new Error(HttpStatusCode.BadRequest, $"Expected {paramName} to be an integer value");
+            };
+
+            return Pipeline.Success(result);
         }
     }
 }

--- a/tests/API/Integration/BuildingRelationshipsTests.cs
+++ b/tests/API/Integration/BuildingRelationshipsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Models;
@@ -42,12 +43,26 @@ namespace Integration
 				Assert.AreEqual(expected.Building.Id, actual.Building.Id);
 				Assert.AreEqual(expected.Unit.Id, actual.Unit.Id);
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            {
+                var resp = await GetAuthenticated("buildingRelationships/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected relationshipId to be an integer value"));
+            }
+        }
 
 		public class BuildingRelationshipCreate : ApiTest
 		{
-			private BuildingRelationshipRequest CityHallParksAndRec = new BuildingRelationshipRequest
-			{
+			private readonly BuildingRelationshipRequest CityHallParksAndRec = new()
+            {
 				UnitId = TestEntities.Units.ParksAndRecUnitId,
 				BuildingId = TestEntities.Buildings.CityHallId
 			};
@@ -167,9 +182,23 @@ namespace Integration
 
 				await DeleteReturnsCorrectEntityPermissions($"buildingRelationships/{relationship.Id}", unitWithPermissions, providedPermission, expectedCode, expectedPermission);
 			}
-		}
 
-		public static async Task<BuildingRelationship> GenerateParksAndRecCabinRelationship()
+            [Test]
+            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            {
+                var resp = await DeleteAuthenticated($"buildingRelationships/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected relationshipId to be an integer value"));
+            }
+        }
+
+        public static async Task<BuildingRelationship> GenerateParksAndRecCabinRelationship()
 		{
 			var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
 			var relationship = new BuildingRelationship

--- a/tests/API/Integration/BuildingsTests.cs
+++ b/tests/API/Integration/BuildingsTests.cs
@@ -91,7 +91,7 @@ namespace Integration
 			}
 
             [Test]
-            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            public async Task ReturnsBadRequestWhenBuildingIdInvalid()
             {
                 var resp = await GetAuthenticated("buildings/invalid");
                 AssertStatusCode(resp, HttpStatusCode.BadRequest);
@@ -127,7 +127,7 @@ namespace Integration
 			}
 
             [Test]
-            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            public async Task ReturnsBadRequestWhenBuildingIdInvalid()
             {
                 var resp = await GetAuthenticated("buildings/invalid/supportingunits");
                 AssertStatusCode(resp, HttpStatusCode.BadRequest);

--- a/tests/API/Integration/BuildingsTests.cs
+++ b/tests/API/Integration/BuildingsTests.cs
@@ -89,7 +89,21 @@ namespace Integration
 				Assert.AreEqual(expected.Name, actual.Name);
 				Assert.AreEqual(expected.Code, actual.Code);
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            {
+                var resp = await GetAuthenticated("buildings/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected buildingId to be an integer value"));
+            }
+        }
 		public class GetSupportingUnits : ApiTest
 		{
 			[TestCase(TestEntities.Buildings.CityHallId, HttpStatusCode.OK)]
@@ -111,7 +125,21 @@ namespace Integration
 				Assert.That(actual.First().Building.Id, Is.EqualTo(expected.First().Building.Id));
 				Assert.That(actual.First().Unit.Id, Is.EqualTo(expected.First().Unit.Id));
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            {
+                var resp = await GetAuthenticated("buildings/invalid/supportingunits");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected buildingId to be an integer value"));
+            }
+        }
 
 	}
 }

--- a/tests/API/Integration/DepartmentsTests.cs
+++ b/tests/API/Integration/DepartmentsTests.cs
@@ -88,7 +88,21 @@ namespace Integration
 				Assert.AreEqual(expected.Name, actual.Name);
 				Assert.AreEqual(expected.Description, actual.Description);
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenDepartmentIdInvalid()
+            {
+                var resp = await GetAuthenticated("departments/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected departmentId to be an integer value"));
+            }
+        }
 
 		public class GetMemberUnits : ApiTest
 		{
@@ -154,7 +168,21 @@ namespace Integration
 				Assert.AreEqual(1, actual.Count);
 				Assert.True(actual.Any(u => u.Id.Equals(TestEntities.Units.AuditorId)));
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenDepartmentIdInvalid()
+            {
+                var resp = await GetAuthenticated("departments/invalid/memberUnits");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected departmentId to be an integer value"));
+            }
+        }
 
 		public class GetSupportingUnits : ApiTest
 		{
@@ -179,6 +207,20 @@ namespace Integration
 				Assert.That(actual.First().SupportType.Id, Is.EqualTo(expected.First().SupportType.Id));
 				Assert.That(actual.First().Unit.Id, Is.EqualTo(expected.First().Unit.Id));
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenDepartmentIdInvalid()
+            {
+                var resp = await GetAuthenticated("departments/invalid/supportingUnits");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected departmentId to be an integer value"));
+            }
+        }
 	}
 }

--- a/tests/API/Integration/PeopleTests.cs
+++ b/tests/API/Integration/PeopleTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Integration
 {
-	public class PeopleTests
+    public class PeopleTests
     {
         public class GetAll : ApiTest
         {
@@ -55,9 +55,9 @@ namespace Integration
                 Assert.AreEqual(4, actual.Count);
             }
 
-            [TestCase("rswanso", Description="Exact match of netid")]
-            [TestCase("RSWANSO", Description="Search is case-insensitive")]
-            [TestCase("rSwaN", Description="Partial netid match")]
+            [TestCase("rswanso", Description = "Exact match of netid")]
+            [TestCase("RSWANSO", Description = "Search is case-insensitive")]
+            [TestCase("rSwaN", Description = "Partial netid match")]
             public async Task CanSearchByNetid(string netid)
             {
                 var resp = await GetAuthenticated($"people?q={netid}");
@@ -67,15 +67,15 @@ namespace Integration
                 Assert.AreEqual(TestEntities.People.RSwanson.Id, actual.Single().Id);
             }
 
-            [TestCase("Ron", Description="Name match")]
-            [TestCase("Swanson,Ron", Description="Alternate format match")]
-            [TestCase("Swanson, Ron", Description="Alternate format with space match")]
-            [TestCase("Swanso, Ro", Description="Alternate format partial match")]
-            [TestCase(" Swanson  ,   Ron ", Description="Alternate format match with weird spacing")]
-            [TestCase("Ron Swanson", Description="Strict format match")]
-            [TestCase("Ro", Description="Partial name match")]
-            [TestCase(",   Ron ", Description="Alternate format match with weird spacing")]
-            [TestCase("Swanson  ,", Description="Alternate format match with weird spacing")]
+            [TestCase("Ron", Description = "Name match")]
+            [TestCase("Swanson,Ron", Description = "Alternate format match")]
+            [TestCase("Swanson, Ron", Description = "Alternate format with space match")]
+            [TestCase("Swanso, Ro", Description = "Alternate format partial match")]
+            [TestCase(" Swanson  ,   Ron ", Description = "Alternate format match with weird spacing")]
+            [TestCase("Ron Swanson", Description = "Strict format match")]
+            [TestCase("Ro", Description = "Partial name match")]
+            [TestCase(",   Ron ", Description = "Alternate format match with weird spacing")]
+            [TestCase("Swanson  ,", Description = "Alternate format match with weird spacing")]
             public async Task CanSearchByName(string name)
             {
                 var resp = await GetAuthenticated($"people?q={name}");
@@ -88,19 +88,19 @@ namespace Integration
 
             [TestCase(
                 Responsibilities.ItLeadership,
-                new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
+                new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
             [TestCase(
                 Responsibilities.ItProjectMgt,
-                new int[]{ TestEntities.People.LKnopeId, TestEntities.People.BWyattId })]
+                new int[] { TestEntities.People.LKnopeId, TestEntities.People.BWyattId })]
             [TestCase(
                 Responsibilities.ItLeadership | Responsibilities.ItProjectMgt,
-                new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId })]
+                new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId })]
             [TestCase(
                 Responsibilities.BizSysAnalysis,
                 new int[0])]
             [TestCase(
                 Responsibilities.BizSysAnalysis | Responsibilities.ItLeadership,
-                new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
+                new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
             public async Task CanSearchByJobClass(Responsibilities jobClass, int[] expectedMatches)
             {
                 var resp = await GetAuthenticated($"people?class={jobClass.ToString()}");
@@ -110,14 +110,14 @@ namespace Integration
             }
 
             [TestCase("programming", new int[0])]
-            [TestCase("Woodworking; Honor", new int[]{TestEntities.People.RSwansonId}, Description="exact match")]
-            [TestCase("woodworking; honor", new int[]{TestEntities.People.RSwansonId}, Description="exact match case-insensitive")]
-            [TestCase("woodworking", new int[]{TestEntities.People.RSwansonId})]
-            [TestCase("working", new int[]{TestEntities.People.RSwansonId})]
-            [TestCase("wood", new int[]{TestEntities.People.RSwansonId})]
-            [TestCase("programming, woodworking", new int[]{TestEntities.People.RSwansonId})]
-            [TestCase("woodworking, waffles", new int[]{TestEntities.People.RSwansonId, TestEntities.People.LKnopeId})]
-            [TestCase("woOdworKing, waFFlEs", new int[]{TestEntities.People.RSwansonId, TestEntities.People.LKnopeId})]
+            [TestCase("Woodworking; Honor", new int[] { TestEntities.People.RSwansonId }, Description = "exact match")]
+            [TestCase("woodworking; honor", new int[] { TestEntities.People.RSwansonId }, Description = "exact match case-insensitive")]
+            [TestCase("woodworking", new int[] { TestEntities.People.RSwansonId })]
+            [TestCase("working", new int[] { TestEntities.People.RSwansonId })]
+            [TestCase("wood", new int[] { TestEntities.People.RSwansonId })]
+            [TestCase("programming, woodworking", new int[] { TestEntities.People.RSwansonId })]
+            [TestCase("woodworking, waffles", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
+            [TestCase("woOdworKing, waFFlEs", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId })]
             public async Task CanSearchByInterest(string interest, int[] expectedMatches)
             {
                 var resp = await GetAuthenticated($"people?interest={interest}");
@@ -126,10 +126,10 @@ namespace Integration
                 AssertIdsMatchContent(expectedMatches, actual);
             }
 
-            [TestCase("Pawnee", new int[]{TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.ServiceAdminId}, Description="full match of Pawnee")]
-            [TestCase("Ind", new int[]{TestEntities.People.BWyattId}, Description="start of Indianapolis")]
-            [TestCase("Indianapolis", new int[]{TestEntities.People.BWyattId}, Description="full match of Indianapolis")]
-            [TestCase("Pawnee, Indian", new int[]{TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId}, Description="multiple campus")]
+            [TestCase("Pawnee", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.ServiceAdminId }, Description = "full match of Pawnee")]
+            [TestCase("Ind", new int[] { TestEntities.People.BWyattId }, Description = "start of Indianapolis")]
+            [TestCase("Indianapolis", new int[] { TestEntities.People.BWyattId }, Description = "full match of Indianapolis")]
+            [TestCase("Pawnee, Indian", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId }, Description = "multiple campus")]
             public async Task CanSearchCampus(string campusName, int[] expectedMatches)
             {
                 var resp = await GetAuthenticated($"people?campus={campusName}");
@@ -138,11 +138,11 @@ namespace Integration
                 AssertIdsMatchContent(expectedMatches, actual);
             }
 
-            [TestCase("Leader", new int[]{ TestEntities.People.RSwansonId, TestEntities.People.ServiceAdminId }, Description = "Return group Leader(s)")]
-            [TestCase("Sublead", new int[]{ TestEntities.People.LKnopeId }, Description = "Return group Subleader(s)")]
-            [TestCase("Member", new int[]{ TestEntities.People.BWyattId }, Description = "Return group Member(s)")]
-            [TestCase("member", new int[]{ TestEntities.People.BWyattId }, Description = "Return group Member(s) case-insensitive")]
-            [TestCase("leader, member", new int[]{ TestEntities.People.RSwansonId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId }, Description = "Support list of roles")]
+            [TestCase("Leader", new int[] { TestEntities.People.RSwansonId, TestEntities.People.ServiceAdminId }, Description = "Return group Leader(s)")]
+            [TestCase("Sublead", new int[] { TestEntities.People.LKnopeId }, Description = "Return group Subleader(s)")]
+            [TestCase("Member", new int[] { TestEntities.People.BWyattId }, Description = "Return group Member(s)")]
+            [TestCase("member", new int[] { TestEntities.People.BWyattId }, Description = "Return group Member(s) case-insensitive")]
+            [TestCase("leader, member", new int[] { TestEntities.People.RSwansonId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId }, Description = "Support list of roles")]
             public async Task CanSearchByRole(string roles, int[] expectedMatches)
             {
                 var resp = await GetAuthenticated($"people?role={roles}");
@@ -151,12 +151,12 @@ namespace Integration
                 AssertIdsMatchContent(expectedMatches, actual);
             }
 
-            [TestCase("Owner", new int[]{ TestEntities.People.RSwansonId })]
-            [TestCase("Viewer", new int[]{ TestEntities.People.LKnopeId })]
-            [TestCase("ManageMembers", new int[]{ TestEntities.People.ServiceAdminId })]
-            [TestCase("managemembers", new int[]{ TestEntities.People.ServiceAdminId }, Description = "Case insensitive match for Permissions.")]
+            [TestCase("Owner", new int[] { TestEntities.People.RSwansonId })]
+            [TestCase("Viewer", new int[] { TestEntities.People.LKnopeId })]
+            [TestCase("ManageMembers", new int[] { TestEntities.People.ServiceAdminId })]
+            [TestCase("managemembers", new int[] { TestEntities.People.ServiceAdminId }, Description = "Case insensitive match for Permissions.")]
             [TestCase("ManageTools", new int[] { TestEntities.People.BWyattId })]
-            [TestCase("Viewer, ManageMembers", new int[]{ TestEntities.People.LKnopeId, TestEntities.People.ServiceAdminId }, Description = "Multiple Permissions provided.")]
+            [TestCase("Viewer, ManageMembers", new int[] { TestEntities.People.LKnopeId, TestEntities.People.ServiceAdminId }, Description = "Multiple Permissions provided.")]
             public async Task CanSearchByPermission(string permissions, int[] expectedMatches)
             {
                 var resp = await GetAuthenticated($"people?permission={permissions}");
@@ -164,10 +164,10 @@ namespace Integration
                 var actual = await resp.Content.ReadAsAsync<List<Person>>();
                 AssertIdsMatchContent(expectedMatches, actual);
             }
-            [TestCase("UITS", new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId }, Description = "All people in UITS area")]
-            [TestCase("uits", new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId})]
+            [TestCase("UITS", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId }, Description = "All people in UITS area")]
+            [TestCase("uits", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId })]
             [TestCase("edge", new int[0])]
-            [TestCase("uits,edge", new int[]{ TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId})]
+            [TestCase("uits,edge", new int[] { TestEntities.People.RSwansonId, TestEntities.People.LKnopeId, TestEntities.People.BWyattId, TestEntities.People.ServiceAdminId })]
             public async Task CanSearchByArea(string areas, int[] expectedMatches)
             {
                 var resp = await GetAuthenticated($"people?area={areas}");
@@ -209,15 +209,15 @@ namespace Integration
                 Assert.AreEqual(expected.Name, actual.Department.Name);
             }
 
-            [TestCase(ValidRswansonJwt, TestEntities.People.RSwansonId, PermsGroups.GetPut, Description="As Ron I can update my own record")]
-            [TestCase(ValidRswansonJwt, TestEntities.People.LKnopeId, PermsGroups.GetPut, Description="As Ron I can update a person in a unit I manage")]
-            [TestCase(ValidRswansonJwt, TestEntities.People.BWyattId, EntityPermissions.Get, Description="As Ron I cannot update a person in a unit I don't manage")]
-            [TestCase(ValidRswansonJwt, TestEntities.People.ServiceAdminId, EntityPermissions.Get, Description="As Ron I cannot update a person in a unit I don't manage")]
-            [TestCase(ValidAdminJwt, TestEntities.People.RSwansonId, PermsGroups.GetPut, Description="As a service admin I can update anyone")]
-            [TestCase(ValidAdminJwt, TestEntities.People.LKnopeId, PermsGroups.GetPut, Description="As a service admin I can update anyone")]
-            [TestCase(ValidAdminJwt, TestEntities.People.BWyattId, PermsGroups.GetPut, Description="As a service admin I can update anyone")]
-            [TestCase(ValidAdminJwt, TestEntities.People.ServiceAdminId, PermsGroups.GetPut, Description="As a service admin I can update anyone")]
-            [TestCase(ValidServiceAcct, TestEntities.People.RSwansonId, EntityPermissions.Get, Description="As a service account I can get anyone")]
+            [TestCase(ValidRswansonJwt, TestEntities.People.RSwansonId, PermsGroups.GetPut, Description = "As Ron I can update my own record")]
+            [TestCase(ValidRswansonJwt, TestEntities.People.LKnopeId, PermsGroups.GetPut, Description = "As Ron I can update a person in a unit I manage")]
+            [TestCase(ValidRswansonJwt, TestEntities.People.BWyattId, EntityPermissions.Get, Description = "As Ron I cannot update a person in a unit I don't manage")]
+            [TestCase(ValidRswansonJwt, TestEntities.People.ServiceAdminId, EntityPermissions.Get, Description = "As Ron I cannot update a person in a unit I don't manage")]
+            [TestCase(ValidAdminJwt, TestEntities.People.RSwansonId, PermsGroups.GetPut, Description = "As a service admin I can update anyone")]
+            [TestCase(ValidAdminJwt, TestEntities.People.LKnopeId, PermsGroups.GetPut, Description = "As a service admin I can update anyone")]
+            [TestCase(ValidAdminJwt, TestEntities.People.BWyattId, PermsGroups.GetPut, Description = "As a service admin I can update anyone")]
+            [TestCase(ValidAdminJwt, TestEntities.People.ServiceAdminId, PermsGroups.GetPut, Description = "As a service admin I can update anyone")]
+            [TestCase(ValidServiceAcct, TestEntities.People.RSwansonId, EntityPermissions.Get, Description = "As a service account I can get anyone")]
             public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, int personId, EntityPermissions expectedPermissions)
             {
                 var resp = await GetAuthenticated($"people/{personId}", jwt);
@@ -281,9 +281,9 @@ namespace Integration
                 Responsibilities = Responsibilities.ItLeadership & Responsibilities.ItProjectMgt,
             };
 
-            [TestCase(TestEntities.People.RSwansonId, ValidRswansonJwt, Description="I can update my own record")]
-            [TestCase(TestEntities.People.LKnopeId, ValidRswansonJwt, Description="I can update a person in a unit I manage")]
-            [TestCase(TestEntities.People.RSwansonId, ValidAdminJwt, Description="Service Admin can edit any person")]
+            [TestCase(TestEntities.People.RSwansonId, ValidRswansonJwt, Description = "I can update my own record")]
+            [TestCase(TestEntities.People.LKnopeId, ValidRswansonJwt, Description = "I can update a person in a unit I manage")]
+            [TestCase(TestEntities.People.RSwansonId, ValidAdminJwt, Description = "Service Admin can edit any person")]
             public async Task AuthorizedUserCanUpdatePerson(int personId, string jwt)
             {
                 //Make a request as a Unit Owner
@@ -307,6 +307,20 @@ namespace Integration
                 // Ben belongs to a unit that Ron doesn't manage. Ron shouln't be able to modify Ben's record.
                 var resp = await PutAuthenticated($"people/{TestEntities.People.BWyattId}", TestUpdateRequest);
                 AssertStatusCode(resp, HttpStatusCode.Forbidden);
+            }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenPersonIdInvalid()
+            {
+                var resp = await PutAuthenticated("people/invalid", TestUpdateRequest, ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected personId to be an integer value"));
             }
         }
 
@@ -390,13 +404,14 @@ namespace Integration
             {
                 var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
                 //Start by adding additional results to HrPeople.  So many records that we don't want to return them all at once.
-                for(var n = 1; n < 27; n++)
+                for (var n = 1; n < 27; n++)
                 {
                     db.HrPeople.Add(new HrPerson { Id = TestEntities.HrPeople.Tammy1Id + n, Netid = $"tammy{n}", Name = $"Swanson, Tammy{n}", Campus = "Pawnee", HrDepartment = "N/A" });
                 }
                 await db.SaveChangesAsync();
             }
         }
+
         public class WithHrGeOne : ApiTest
         {
 

--- a/tests/API/Integration/SupportRelationshipsTests.cs
+++ b/tests/API/Integration/SupportRelationshipsTests.cs
@@ -47,9 +47,23 @@ namespace Integration
 				Assert.AreEqual(expected.Unit.Id, actual.Unit.Id);
 				Assert.AreEqual(expected.SupportType.Id, actual.SupportType.Id);
 			}
-		}
 
-		public class SupportRelationshipCreate : ApiTest
+            [Test]
+            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            {
+                var resp = await GetAuthenticated("supportRelationships/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected relationshipId to be an integer value"));
+            }
+        }
+
+        public class SupportRelationshipCreate : ApiTest
 		{
 			private SupportRelationshipRequest FireAuditor = new SupportRelationshipRequest
 			{
@@ -196,7 +210,21 @@ namespace Integration
 
 				await DeleteReturnsCorrectEntityPermissions($"supportRelationships/{relationship.Id}", unitWithPermissions, providedPermission, expectedCode, expectedPermission);
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenRelationshipIdInvalid()
+            {
+                var resp = await DeleteAuthenticated("supportRelationships/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected relationshipId to be an integer value"));
+            }
+        }
 
 		public static async Task<SupportRelationship> GenerateParksAndRecSupportingAuditDept()
 		{

--- a/tests/API/Integration/UnitMemberToolsTests.cs
+++ b/tests/API/Integration/UnitMemberToolsTests.cs
@@ -216,7 +216,21 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
             }
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenMemberToolIdInvalid()
+            {
+                var resp = await GetAuthenticated("membertools/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected memberToolId to be an integer value"));
+            }
+        }
 
 		public class UnitMemberToolsCreate : ApiTest
 		{
@@ -428,7 +442,28 @@ namespace Integration
 				Assert.Contains(ArchivedUnitError, actual.Errors);
 				Assert.AreEqual("(none)", actual.Details);
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenMembershipIdInvalid()
+            {
+                var req = new MemberToolRequest
+                {
+                    Id = TestEntities.MemberTools.AdminHammerId,
+                    MembershipId = TestEntities.UnitMembers.LkNopeSubleadId,
+                    ToolId = TestEntities.Tools.HammerId
+                };
+
+                var resp = await PutAuthenticated("membertools/invalid", req, ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected memberToolId to be an integer value"));
+            }
+        }
 
 		public class UnitMemberToolsDelete : ApiTest
 		{
@@ -441,7 +476,22 @@ namespace Integration
 				var resp = await DeleteAuthenticated($"membertools/{memberToolId}", jwt);
 				AssertStatusCode(resp, expectedCode);
 			}
-			/*
+
+            [Test]
+            public async Task ReturnsBadRequestWhenMemberToolIdInvalid()
+            {
+                var resp = await DeleteAuthenticated("membertools/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected memberToolId to be an integer value"));
+            }
+
+            /*
 			[Test]
 			public async Task DeleteUnitMemberToolDoesNotCreateOrphans()
 			{
@@ -455,6 +505,6 @@ namespace Integration
 				Assert.IsEmpty(db.MemberTools.Where(mt => mt.UnitMember == null));
 			}
 			*/
-		}
+        }
 	}
 }

--- a/tests/API/Integration/UnitMembersTests.cs
+++ b/tests/API/Integration/UnitMembersTests.cs
@@ -47,55 +47,55 @@ namespace Integration
 				Assert.NotNull(ron.Unit);
 				Assert.NotNull(ron.Unit.Parent);
 				Assert.NotNull(ron.MemberTools);
-			}
-		}
+            }
+        }
 
-		public class GetOne : ApiTest
-		{
-			[TestCase(TestEntities.UnitMembers.RSwansonLeaderId, HttpStatusCode.OK)]
-			[TestCase(TestEntities.UnitMembers.ArchivedRonId, HttpStatusCode.OK)]
-			[TestCase(9999, HttpStatusCode.NotFound)]
-			public async Task UnitMemberHasCorrectStatusCode(int id, HttpStatusCode expectedStatus)
-			{
-				var resp = await GetAuthenticated($"memberships/{id}");
-				AssertStatusCode(resp, expectedStatus);
-			}
+        public class GetOne : ApiTest
+        {
+            [TestCase(TestEntities.UnitMembers.RSwansonLeaderId, HttpStatusCode.OK)]
+            [TestCase(TestEntities.UnitMembers.ArchivedRonId, HttpStatusCode.OK)]
+            [TestCase(9999, HttpStatusCode.NotFound)]
+            public async Task UnitMemberHasCorrectStatusCode(int id, HttpStatusCode expectedStatus)
+            {
+                var resp = await GetAuthenticated($"memberships/{id}");
+                AssertStatusCode(resp, expectedStatus);
+            }
 
-			[Test]
-			public async Task UnitMemberResponseHasCorrectShape()
-			{
-				var resp = await GetAuthenticated($"memberships/{TestEntities.UnitMembers.LkNopeSubleadId}");
-				AssertStatusCode(resp, HttpStatusCode.OK);
-				var actual = await resp.Content.ReadAsAsync<UnitMemberResponse>();
-				var expected = TestEntities.UnitMembers.LkNopeSublead;
-				Assert.AreEqual(expected.Id, actual.Id);
-				Assert.AreEqual(expected.UnitId, actual.UnitId);
-				Assert.AreEqual(expected.Role, actual.Role);
-				Assert.AreEqual(expected.Permissions, actual.Permissions);
-				Assert.AreEqual(expected.PersonId, actual.PersonId);
-				Assert.AreEqual(expected.Title, actual.Title);
-				Assert.AreEqual(expected.Percentage, actual.Percentage);
-				Assert.AreEqual(expected.Notes, actual.Notes); //Notes are stripped on membership getters
-				// relations
-				Assert.NotNull(actual.Person);
-				Assert.AreEqual(expected.Person.Id, actual.Person.Id);
-				Assert.NotNull(actual.Unit);
-				Assert.AreEqual(expected.Unit.Id, actual.Unit.Id);
-				Assert.NotNull(actual.MemberTools);
-			}
+            [Test]
+            public async Task UnitMemberResponseHasCorrectShape()
+            {
+                var resp = await GetAuthenticated($"memberships/{TestEntities.UnitMembers.LkNopeSubleadId}");
+                AssertStatusCode(resp, HttpStatusCode.OK);
+                var actual = await resp.Content.ReadAsAsync<UnitMemberResponse>();
+                var expected = TestEntities.UnitMembers.LkNopeSublead;
+                Assert.AreEqual(expected.Id, actual.Id);
+                Assert.AreEqual(expected.UnitId, actual.UnitId);
+                Assert.AreEqual(expected.Role, actual.Role);
+                Assert.AreEqual(expected.Permissions, actual.Permissions);
+                Assert.AreEqual(expected.PersonId, actual.PersonId);
+                Assert.AreEqual(expected.Title, actual.Title);
+                Assert.AreEqual(expected.Percentage, actual.Percentage);
+                Assert.AreEqual(expected.Notes, actual.Notes); //Notes are stripped on membership getters
+                                                               // relations
+                Assert.NotNull(actual.Person);
+                Assert.AreEqual(expected.Person.Id, actual.Person.Id);
+                Assert.NotNull(actual.Unit);
+                Assert.AreEqual(expected.Unit.Id, actual.Unit.Id);
+                Assert.NotNull(actual.MemberTools);
+            }
 
-			[TestCase(ValidRswansonJwt, TestEntities.UnitMembers.RSwansonLeaderId, PermsGroups.All, TestName="Ron1", Description="As Ron (owner) I can manage Ron's membership")]
-			[TestCase(ValidRswansonJwt, TestEntities.UnitMembers.LkNopeSubleadId, PermsGroups.All, TestName="Ron2", Description="As Ron (owner) I can manage Leslie's membership")]
-			[TestCase(ValidRswansonJwt, TestEntities.UnitMembers.BWyattMemberId, EntityPermissions.Get, TestName="Ron3", Description="As Ron (owner) I can't manage Ben's membership (different unit)")]
-			[TestCase(ValidLknopeJwt, TestEntities.UnitMembers.RSwansonLeaderId, EntityPermissions.Get, TestName="Les1", Description="As Leslie (viewer) I can't manage Ron's membership")]
-			[TestCase(ValidLknopeJwt, TestEntities.UnitMembers.LkNopeSubleadId, EntityPermissions.Get, TestName="Les2", Description="As Leslie (viewer) I can't manage Leslies's membership")]
-            [TestCase(ValidLknopeJwt, TestEntities.UnitMembers.BWyattMemberId, EntityPermissions.Get, TestName="Les3", Description="As Leslie (viewer) I can't manage Ben's membership")]
-			[TestCase(ValidBwyattJwt, TestEntities.UnitMembers.RSwansonLeaderId, EntityPermissions.Get, TestName="Ben2", Description="As Ben (ManageMebers) I can't manage Ron's membership (different unit)")]
-			[TestCase(ValidBwyattJwt, TestEntities.UnitMembers.LkNopeSubleadId,  EntityPermissions.Get, TestName="Ben3", Description="As Ben (ManageMebers) I can't manage Leslie's membership (different unit)")]
-            [TestCase(ValidAdminJwt, TestEntities.UnitMembers.RSwansonLeaderId, PermsGroups.All, TestName="Adm1", Description="As a service admin I can do anything to any unit")]
-            [TestCase(ValidAdminJwt, TestEntities.UnitMembers.LkNopeSubleadId, PermsGroups.All, TestName="Adm2", Description="As a service admin I can do anything to any unit")]
-            [TestCase(ValidAdminJwt, TestEntities.UnitMembers.BWyattMemberId, PermsGroups.All, TestName="Adm3", Description="As a service admin I can do anything to any unit")]
-			[TestCase(ValidServiceAcct, TestEntities.UnitMembers.BWyattMemberId, EntityPermissions.Get, TestName="Svc1", Description="As a service account I can only get unit membership")]
+            [TestCase(ValidRswansonJwt, TestEntities.UnitMembers.RSwansonLeaderId, PermsGroups.All, TestName = "Ron1", Description = "As Ron (owner) I can manage Ron's membership")]
+            [TestCase(ValidRswansonJwt, TestEntities.UnitMembers.LkNopeSubleadId, PermsGroups.All, TestName = "Ron2", Description = "As Ron (owner) I can manage Leslie's membership")]
+            [TestCase(ValidRswansonJwt, TestEntities.UnitMembers.BWyattMemberId, EntityPermissions.Get, TestName = "Ron3", Description = "As Ron (owner) I can't manage Ben's membership (different unit)")]
+            [TestCase(ValidLknopeJwt, TestEntities.UnitMembers.RSwansonLeaderId, EntityPermissions.Get, TestName = "Les1", Description = "As Leslie (viewer) I can't manage Ron's membership")]
+            [TestCase(ValidLknopeJwt, TestEntities.UnitMembers.LkNopeSubleadId, EntityPermissions.Get, TestName = "Les2", Description = "As Leslie (viewer) I can't manage Leslies's membership")]
+            [TestCase(ValidLknopeJwt, TestEntities.UnitMembers.BWyattMemberId, EntityPermissions.Get, TestName = "Les3", Description = "As Leslie (viewer) I can't manage Ben's membership")]
+            [TestCase(ValidBwyattJwt, TestEntities.UnitMembers.RSwansonLeaderId, EntityPermissions.Get, TestName = "Ben2", Description = "As Ben (ManageMebers) I can't manage Ron's membership (different unit)")]
+            [TestCase(ValidBwyattJwt, TestEntities.UnitMembers.LkNopeSubleadId, EntityPermissions.Get, TestName = "Ben3", Description = "As Ben (ManageMebers) I can't manage Leslie's membership (different unit)")]
+            [TestCase(ValidAdminJwt, TestEntities.UnitMembers.RSwansonLeaderId, PermsGroups.All, TestName = "Adm1", Description = "As a service admin I can do anything to any unit")]
+            [TestCase(ValidAdminJwt, TestEntities.UnitMembers.LkNopeSubleadId, PermsGroups.All, TestName = "Adm2", Description = "As a service admin I can do anything to any unit")]
+            [TestCase(ValidAdminJwt, TestEntities.UnitMembers.BWyattMemberId, PermsGroups.All, TestName = "Adm3", Description = "As a service admin I can do anything to any unit")]
+            [TestCase(ValidServiceAcct, TestEntities.UnitMembers.BWyattMemberId, EntityPermissions.Get, TestName = "Svc1", Description = "As a service account I can only get unit membership")]
             public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, int membershipId, EntityPermissions expectedPermissions)
             {
                 var resp = await GetAuthenticated($"memberships/{membershipId}", jwt);
@@ -103,56 +103,69 @@ namespace Integration
                 AssertPermissions(resp, expectedPermissions);
             }
 
-			[Test]
-			public async Task ResponseInheritsXUserPermissionsFromParentUnit()
-			{
-				// Add a person to City of Pawnee that has All permissions on "City of Pawnee," but NO permissions directly on "Parks & Rec."
-				var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
-				var chris =  new Person()
-				{
-					Netid = "ctraeger",
-					Name = "Traeger, Chris",
-					NameFirst = "Chris",
-					NameLast = "Traeger",
-					Position = "Sr. Auditor",
-					Location = "",
-					Campus = "Indianapolis",
-					CampusPhone = "317.441.3333",
-					CampusEmail = "ctraeger@pawnee.in.us",
-					Expertise = "Fitness",
-					Notes = "",
-					PhotoUrl = "https://sasquatchbrewery.com/wp-content/uploads/2018/06/lil.jpg",
-					Responsibilities = Responsibilities.ItProjectMgt,
-					DepartmentId = TestEntities.Departments.Auditor.Id,
-					IsServiceAdmin = false
-				};
-				await db.People.AddAsync(chris);
+            [Test]
+            public async Task ResponseInheritsXUserPermissionsFromParentUnit()
+            {
+                // Add a person to City of Pawnee that has All permissions on "City of Pawnee," but NO permissions directly on "Parks & Rec."
+                var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
+                var chris = new Person()
+                {
+                    Netid = "ctraeger",
+                    Name = "Traeger, Chris",
+                    NameFirst = "Chris",
+                    NameLast = "Traeger",
+                    Position = "Sr. Auditor",
+                    Location = "",
+                    Campus = "Indianapolis",
+                    CampusPhone = "317.441.3333",
+                    CampusEmail = "ctraeger@pawnee.in.us",
+                    Expertise = "Fitness",
+                    Notes = "",
+                    PhotoUrl = "https://sasquatchbrewery.com/wp-content/uploads/2018/06/lil.jpg",
+                    Responsibilities = Responsibilities.ItProjectMgt,
+                    DepartmentId = TestEntities.Departments.Auditor.Id,
+                    IsServiceAdmin = false
+                };
+                await db.People.AddAsync(chris);
 
-				// Add chris to City of Pawnee with All permissions
-				var chrisCityMembership = new UnitMember()
-				{
-					Role = Role.Member,
-					Permissions = UnitPermissions.ManageMembers,
-					PersonId = chris.Id,
-					Title = "Auditor",
-					Percentage = 100,
-					Notes = "notes about Chris",
-					Person = chris,
-					UnitId = TestEntities.Units.CityOfPawneeUnitId,
-					MemberTools = null
-				};
-				await db.UnitMembers.AddAsync(chrisCityMembership);
-				await db.SaveChangesAsync();
+                // Add chris to City of Pawnee with All permissions
+                var chrisCityMembership = new UnitMember()
+                {
+                    Role = Role.Member,
+                    Permissions = UnitPermissions.ManageMembers,
+                    PersonId = chris.Id,
+                    Title = "Auditor",
+                    Percentage = 100,
+                    Notes = "notes about Chris",
+                    Person = chris,
+                    UnitId = TestEntities.Units.CityOfPawneeUnitId,
+                    MemberTools = null
+                };
+                await db.UnitMembers.AddAsync(chrisCityMembership);
+                await db.SaveChangesAsync();
 
-				// Get "parks & rec", they should have PermsGroups.All because "City of Pawnee" is "Parks & Rec's" parent.
-				var resp = await GetAuthenticated($"memberships/{chrisCityMembership.Id}", ValidCtraegerJwt);
+                // Get "parks & rec", they should have PermsGroups.All because "City of Pawnee" is "Parks & Rec's" parent.
+                var resp = await GetAuthenticated($"memberships/{chrisCityMembership.Id}", ValidCtraegerJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
+            }
 
-			}
-		}
+            [Test]
+            public async Task ReturnsBadRequestWhenMembershipIdInvalid()
+            {
+                var resp = await GetAuthenticated("memberships/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
 
-		public class UnitMemberCreate : ApiTest
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected membershipId to be an integer value"));
+            }
+        }
+
+        public class UnitMemberCreate : ApiTest
 		{
 			[TestCase(null, Description = "Create UnitMember with vacancy")]
 			[TestCase(TestEntities.People.RSwansonId, Description = "Create UnitMember with existing person")]
@@ -336,7 +349,8 @@ namespace Integration
 					Percentage = 100,
 					Notes = ""
 				};
-				var resp = await PutAuthenticated($"memberships/{TestEntities.UnitMembers.RSwansonLeaderId}", req, ValidAdminJwt);
+
+				var resp = await PutAuthenticated($"memberships/{unitId}", req, ValidAdminJwt);
 				AssertStatusCode(resp, HttpStatusCode.OK);
 				var actual = await resp.Content.ReadAsAsync<UnitMemberResponse>();
 
@@ -461,7 +475,33 @@ namespace Integration
 				var resp = await PutAuthenticated($"memberships/{TestEntities.UnitMembers.LkNopeSubleadId}", req, ValidAdminJwt);
 				AssertStatusCode(resp, HttpStatusCode.Conflict);
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenMembershipIdInvalid()
+            {
+                var req = new UnitMemberRequest
+                {
+                    UnitId = TestEntities.Units.CityOfPawneeUnitId,
+                    Role = Role.Member,
+                    Permissions = UnitPermissions.Viewer,
+                    PersonId = TestEntities.UnitMembers.RSwansonDirector.PersonId,
+                    Title = "Title",
+                    Percentage = 100,
+                    Notes = ""
+                };
+
+                var resp = await PutAuthenticated("memberships/invalid", req, ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected membershipId to be an integer value"));
+            }
+        }
+
 		public class UnitMembersDelete : ApiTest
 		{
 			[TestCase(TestEntities.UnitMembers.RSwansonLeaderId, ValidAdminJwt, HttpStatusCode.NoContent, Description = "Admin can delete a membership")]
@@ -486,6 +526,20 @@ namespace Integration
 				Assert.IsEmpty(db.MemberTools.Where(mt => mt.Tool == null));
 				Assert.IsEmpty(db.MemberTools.Where(mt => mt.UnitMember == null));
 			}
-		}
+
+            [Test]
+            public async Task ReturnsBadRequestWhenMembershipIdInvalid()
+            {
+                var resp = await DeleteAuthenticated("memberships/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected membershipId to be an integer value"));
+            }
+        }
 	}
 }

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -51,9 +51,9 @@ namespace Integration
                 Assert.AreEqual(0, actual.Count);
             }
 
-            [TestCase(ValidRswansonJwt, EntityPermissions.Get, Description="As non-admin I can't create/delete units")]
-            [TestCase(ValidAdminJwt, PermsGroups.All, Description="As a service admin I can create/modify/delete units")]
-            [TestCase(ValidServiceAcct, EntityPermissions.Get, Description="As a service account I can get, but not create/delete units")]
+            [TestCase(ValidRswansonJwt, EntityPermissions.Get, Description = "As non-admin I can't create/delete units")]
+            [TestCase(ValidAdminJwt, PermsGroups.All, Description = "As a service admin I can create/modify/delete units")]
+            [TestCase(ValidServiceAcct, EntityPermissions.Get, Description = "As a service account I can get, but not create/delete units")]
             public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, EntityPermissions expectedPermissions)
             {
                 var resp = await GetAuthenticated($"units", jwt);
@@ -84,11 +84,11 @@ namespace Integration
             }
 
 
-            [TestCase(ValidRswansonJwt, TestEntities.Units.ParksAndRecUnitId, PermsGroups.GetPut, Description="As Ron I can get and update a unit")]
-            [TestCase(ValidRswansonJwt, TestEntities.Units.CityOfPawneeUnitId, EntityPermissions.Get, Description="As Ron I can't update a unit I don't manage")]
-            [TestCase(ValidAdminJwt, TestEntities.Units.ParksAndRecUnitId, PermsGroups.All, Description="As a service admin I can do anything to any unit")]
-            [TestCase(ValidAdminJwt, TestEntities.Units.CityOfPawneeUnitId, PermsGroups.All, Description="As a service admin I can do anything to any unit")]
-            [TestCase(ValidServiceAcct, TestEntities.Units.ParksAndRecUnitId, EntityPermissions.Get, Description="As a service account I can get a unit")]
+            [TestCase(ValidRswansonJwt, TestEntities.Units.ParksAndRecUnitId, PermsGroups.GetPut, Description = "As Ron I can get and update a unit")]
+            [TestCase(ValidRswansonJwt, TestEntities.Units.CityOfPawneeUnitId, EntityPermissions.Get, Description = "As Ron I can't update a unit I don't manage")]
+            [TestCase(ValidAdminJwt, TestEntities.Units.ParksAndRecUnitId, PermsGroups.All, Description = "As a service admin I can do anything to any unit")]
+            [TestCase(ValidAdminJwt, TestEntities.Units.CityOfPawneeUnitId, PermsGroups.All, Description = "As a service admin I can do anything to any unit")]
+            [TestCase(ValidServiceAcct, TestEntities.Units.ParksAndRecUnitId, EntityPermissions.Get, Description = "As a service account I can get a unit")]
             public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, int unitId, EntityPermissions expectedPermissions)
             {
                 var resp = await GetAuthenticated($"units/{unitId}", jwt);
@@ -106,13 +106,13 @@ namespace Integration
             [TestCase(TestEntities.Units.ParksAndRecUnitId, TestEntities.Units.CityOfPawneeUnitId, UnitPermissions.Owner, PermsGroups.GetPut, Description = "Owner Inheritted From Parent")]
             public async Task ReturnsCorrectPermissionsSingleUnit(int unitToCheck, int unitWithPermissions, UnitPermissions providedPermission, EntityPermissions expectedPermission)
                 => await GetReturnsCorrectEntityPermissions($"units/{unitToCheck}", unitWithPermissions, providedPermission, expectedPermission);
-            
+
             [Test]
             public async Task BegottenUnitPermissions()
             {
                 // Add units 4 levels deep under Parks & Rec unit.
                 var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
-                
+
                 var childUnit = new Unit("Child", "Child of Parks & Rec", "bleh", "bleh@fake.com", TestEntities.Units.ParksAndRecUnitId);
                 await db.Units.AddAsync(childUnit);
                 await db.SaveChangesAsync();
@@ -133,7 +133,7 @@ namespace Integration
                 var resp = await GetAuthenticated($"units/{TestEntities.Units.ParksAndRecUnitId}", ValidRswansonJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.GetPut);
-                
+
                 resp = await GetAuthenticated($"units/{childUnit.Id}", ValidRswansonJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.GetPut);
@@ -150,11 +150,26 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.GetPut);
             }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await GetAuthenticated($"units/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
+            }
         }
 
         public class UnitCreate : ApiTest
         {
-            private Unit ExpectedMayorsOffice = new Unit(){
+            private Unit ExpectedMayorsOffice = new Unit()
+            {
                 Name = "Pawnee Mayor's Office",
                 Description = "The Office of the Mayor",
                 Url = "http://gunderson.geocities.com",
@@ -376,7 +391,7 @@ namespace Integration
                 // Verify the value was removed from the database
                 var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
                 var actual = await db.Units.SingleOrDefaultAsync(u => u.Id == unitId);
-                if(expectedCode == HttpStatusCode.NoContent || expectedCode == HttpStatusCode.NotFound)
+                if (expectedCode == HttpStatusCode.NoContent || expectedCode == HttpStatusCode.NotFound)
                 {
                     Assert.Null(actual);
                 }
@@ -599,7 +614,7 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.NotFound);
             }
 
-            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[]{TestEntities.Units.AuditorId, TestEntities.Units.ParksAndRecUnitId, TestEntities.Units.ArchivedUnitId})]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[] { TestEntities.Units.AuditorId, TestEntities.Units.ParksAndRecUnitId, TestEntities.Units.ArchivedUnitId })]
             [TestCase(TestEntities.Units.AuditorId, new int[0])]
             [TestCase(TestEntities.Units.ParksAndRecUnitId, new int[0])]
             public async Task CanGetExpectedChildren(int unitId, int[] expectedChildIds)
@@ -613,9 +628,9 @@ namespace Integration
                 Assert.True(actual.All(a => a.Parent.Id == unitId));
             }
 
-            [TestCase(ValidRswansonJwt, EntityPermissions.Get, Description="As non-admin I can't create/delete units")]
-            [TestCase(ValidAdminJwt, PermsGroups.All, Description="As a service admin I can create/modify/delete units")]
-            [TestCase(ValidServiceAcct, EntityPermissions.Get, Description="As a service account I can get, but not create/delete units")]
+            [TestCase(ValidRswansonJwt, EntityPermissions.Get, Description = "As non-admin I can't create/delete units")]
+            [TestCase(ValidAdminJwt, PermsGroups.All, Description = "As a service admin I can create/modify/delete units")]
+            [TestCase(ValidServiceAcct, EntityPermissions.Get, Description = "As a service account I can get, but not create/delete units")]
             public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, EntityPermissions expectedPermissions)
             {
                 var resp = await GetAuthenticated($"units/{TestEntities.Units.CityOfPawneeUnitId}/children", jwt);
@@ -649,6 +664,20 @@ namespace Integration
 
                 await GetReturnsCorrectEntityPermissions($"units/{TestEntities.Units.ParksAndRecUnitId}/children", unitWithPermissions, providedPermission, expectedPermission);
             }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await GetAuthenticated($"units/invalid/children");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
+            }
         }
 
         [TestFixture]
@@ -668,9 +697,9 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.NotFound);
             }
 
-            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new []{TestEntities.UnitMembers.AdminMemberId})]
-            [TestCase(TestEntities.Units.AuditorId, new []{TestEntities.UnitMembers.BWyattMemberId})]
-            [TestCase(TestEntities.Units.ParksAndRecUnitId, new []{TestEntities.UnitMembers.RSwansonLeaderId, TestEntities.UnitMembers.LkNopeSubleadId})]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[] { TestEntities.UnitMembers.AdminMemberId })]
+            [TestCase(TestEntities.Units.AuditorId, new[] { TestEntities.UnitMembers.BWyattMemberId })]
+            [TestCase(TestEntities.Units.ParksAndRecUnitId, new[] { TestEntities.UnitMembers.RSwansonLeaderId, TestEntities.UnitMembers.LkNopeSubleadId })]
             public async Task CanGetExpectedMembers(int unitId, int[] expectedMemberIds)
             {
                 var resp = await GetAuthenticated($"units/{unitId}/members");
@@ -679,11 +708,11 @@ namespace Integration
                 AssertIdsMatchContent(expectedMemberIds, actual);
             }
 
-            [TestCase(ValidRswansonJwt, TestEntities.Units.ParksAndRecUnitId, false, Description="Ron sees notes for unit he manages.")]
-            [TestCase(ValidRswansonJwt, TestEntities.Units.AuditorId, true, Description="Ron doesn't see notes for unit he doesn't manage.")]
+            [TestCase(ValidRswansonJwt, TestEntities.Units.ParksAndRecUnitId, false, Description = "Ron sees notes for unit he manages.")]
+            [TestCase(ValidRswansonJwt, TestEntities.Units.AuditorId, true, Description = "Ron doesn't see notes for unit he doesn't manage.")]
             [TestCase(ValidAdminJwt, TestEntities.Units.ParksAndRecUnitId, false)]
             [TestCase(ValidAdminJwt, TestEntities.Units.AuditorId, false)]
-            [TestCase(ValidServiceAcct, TestEntities.Units.AuditorId, true, Description="service account since they do not manage any units.")]
+            [TestCase(ValidServiceAcct, TestEntities.Units.AuditorId, true, Description = "service account since they do not manage any units.")]
             public async Task NotesAreHidden(string requestor, int unitId, bool expectNotesHidden)
             {
                 var resp = await GetAuthenticated($"units/{unitId}/members", requestor);
@@ -697,7 +726,7 @@ namespace Integration
             [TestCase(UnitPermissions.ManageMembers, EntityPermissions.Get, Description = "ManageMember")]
             [TestCase(UnitPermissions.Owner, EntityPermissions.Get, Description = "Owner")]
             public async Task ReturnsCorrectPermissionsWhenUnitRetired(UnitPermissions providedPermission, EntityPermissions expectedPermission)
-			{
+            {
                 await GetReturnsCorrectEntityPermissions($"units/{TestEntities.Units.ArchivedUnitId}/members", TestEntities.Units.ArchivedUnitId, providedPermission, expectedPermission);
             }
 
@@ -707,6 +736,20 @@ namespace Integration
                 var resp = await GetAuthenticated($"units/{TestEntities.Units.ArchivedUnitId}/members", ValidAdminJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
+            }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await GetAuthenticated($"units/invalid/members");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
             }
         }
 
@@ -727,9 +770,9 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.NotFound);
             }
 
-            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[]{TestEntities.BuildingRelationships.CityHallCityOfPawneeId, TestEntities.BuildingRelationships.RonsCabinCityOfPawneeId})]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[] { TestEntities.BuildingRelationships.CityHallCityOfPawneeId, TestEntities.BuildingRelationships.RonsCabinCityOfPawneeId })]
             [TestCase(TestEntities.Units.AuditorId, new int[0])]
-            [TestCase(TestEntities.Units.ParksAndRecUnitId, new int[]{TestEntities.BuildingRelationships.SmallParkParksandRecId})]
+            [TestCase(TestEntities.Units.ParksAndRecUnitId, new int[] { TestEntities.BuildingRelationships.SmallParkParksandRecId })]
             public async Task CanGetExpectedBuildingRelationships(int unitId, int[] expectedRelationIds)
             {
                 var resp = await GetAuthenticated($"units/{unitId}/supportedBuildings");
@@ -769,6 +812,20 @@ namespace Integration
             [TestCase(TestEntities.Units.CityOfPawneeUnitId, UnitPermissions.Owner, PermsGroups.All, Description = "Owner Inheritted From Parent")]
             public async Task ReturnsCorrectPermissionsUnitBuildingRelationship(int unitWithPermissions, UnitPermissions providedPermission, EntityPermissions expectedPermission)
                 => await GetReturnsCorrectEntityPermissions($"units/{TestEntities.Units.ParksAndRecUnitId}/supportedBuildings", unitWithPermissions, providedPermission, expectedPermission);
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await GetAuthenticated($"units/invalid/supportedBuildings");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
+            }
         }
 
 
@@ -791,7 +848,7 @@ namespace Integration
 
             [TestCase(TestEntities.Units.ParksAndRecUnitId, new int[0])]
             [TestCase(TestEntities.Units.AuditorId, new int[0])]
-            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new int[]{TestEntities.SupportRelationships.ParksAndRecRelationshipId, TestEntities.SupportRelationships.PawneeUnitFireId})]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new int[] { TestEntities.SupportRelationships.ParksAndRecRelationshipId, TestEntities.SupportRelationships.PawneeUnitFireId })]
             public async Task CanGetExpectedRelationships(int unitId, int[] expectedRelationIds)
             {
                 var resp = await GetAuthenticated($"units/{unitId}/supportedDepartments");
@@ -851,22 +908,36 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
             }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await GetAuthenticated($"units/invalid/supportedDepartments");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
+            }
         }
 
         [TestFixture]
         public class UnitGetTools : ApiTest
         {
-			[TestCase(ValidLknopeJwt, EntityPermissions.Get, Description = "As non-admin I can't create/delete member tools")]
-			[TestCase(ValidAdminJwt, PermsGroups.All, Description = "As a service admin I can create/modify/delete member tools")]
-			[TestCase(ValidBwyattJwt, PermsGroups.All, Description = "With manage tools permission, I can create/modify/delete member tools")]
+            [TestCase(ValidLknopeJwt, EntityPermissions.Get, Description = "As non-admin I can't create/delete member tools")]
+            [TestCase(ValidAdminJwt, PermsGroups.All, Description = "As a service admin I can create/modify/delete member tools")]
+            [TestCase(ValidBwyattJwt, PermsGroups.All, Description = "With manage tools permission, I can create/modify/delete member tools")]
 
-			public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, EntityPermissions expectedPermissions)
-			{
-				var resp = await GetAuthenticated($"units/3/tools", jwt);
-				AssertPermissions(resp, expectedPermissions);
-			}
+            public async Task ResponseHasCorrectXUserPermissionsHeader(string jwt, EntityPermissions expectedPermissions)
+            {
+                var resp = await GetAuthenticated($"units/3/tools", jwt);
+                AssertPermissions(resp, expectedPermissions);
+            }
 
-			[Test]
+            [Test]
             public async Task AuthRequired()
             {
                 var resp = await GetAuthenticated($"units/{TestEntities.Units.CityOfPawneeUnitId}/tools", "bad token");
@@ -880,9 +951,9 @@ namespace Integration
                 AssertStatusCode(resp, HttpStatusCode.NotFound);
             }
 
-            [TestCase(TestEntities.Units.ParksAndRecUnitId, new[]{TestEntities.Tools.HammerId, TestEntities.Tools.SawId})]
-            [TestCase(TestEntities.Units.AuditorId, new[]{TestEntities.Tools.HammerId, TestEntities.Tools.SawId})]
-            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[]{TestEntities.Tools.HammerId, TestEntities.Tools.SawId})]
+            [TestCase(TestEntities.Units.ParksAndRecUnitId, new[] { TestEntities.Tools.HammerId, TestEntities.Tools.SawId })]
+            [TestCase(TestEntities.Units.AuditorId, new[] { TestEntities.Tools.HammerId, TestEntities.Tools.SawId })]
+            [TestCase(TestEntities.Units.CityOfPawneeUnitId, new[] { TestEntities.Tools.HammerId, TestEntities.Tools.SawId })]
             public async Task CanGetExpectedTools(int unitId, int[] expectedToolIds)
             {
                 var resp = await GetAuthenticated($"units/{unitId}/tools");
@@ -914,13 +985,13 @@ namespace Integration
             [TestCase(UnitPermissions.Owner, PermsGroups.All, Description = "Owner")]
             public async Task ReturnsCorrectPermissionsForUnitPermissions(UnitPermissions providedPermission, EntityPermissions expectedPermission)
                 => await GetReturnsCorrectEntityPermissions($"units/{TestEntities.Units.AuditorId}/tools", TestEntities.Units.AuditorId, providedPermission, expectedPermission);
-            
+
             [Test]
             public async Task BegottenUnitToolsPermissions()
             {
                 // Add units 4 levels deep under Parks & Rec unit.
                 var db = Database.PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
-                
+
                 var childUnit = new Unit("Child", "Child of Parks & Rec", "bleh", "bleh@fake.com", TestEntities.Units.ParksAndRecUnitId);
                 await db.Units.AddAsync(childUnit);
                 await db.SaveChangesAsync();
@@ -941,7 +1012,7 @@ namespace Integration
                 var resp = await GetAuthenticated($"units/{TestEntities.Units.ParksAndRecUnitId}/tools", ValidRswansonJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
-                
+
                 resp = await GetAuthenticated($"units/{childUnit.Id}/tools", ValidRswansonJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
@@ -957,6 +1028,20 @@ namespace Integration
                 resp = await GetAuthenticated($"units/{greatGreatGrandChildUnit.Id}/tools", ValidRswansonJwt);
                 AssertStatusCode(resp, HttpStatusCode.OK);
                 AssertPermissions(resp, PermsGroups.All);
+            }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await GetAuthenticated($"units/invalid/tools");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
             }
         }
     }

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -375,6 +375,22 @@ namespace Integration
                 Assert.AreEqual(existingParksAndRecUnitMembers.Count, resultParksAndRecUnitMembers.Count);
                 AssertIdsMatchContent(existingParksAndRecUnitMembers.Select(m => m.Id).ToArray(), resultParksAndRecUnitMembers);
             }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenMembershipIdInvalid()
+            {
+                var req = new Unit("Eagleton", "Gated Community of Eagleton, Indiana", null, "hoa@eagleton.biz");
+                
+                var resp = await PutAuthenticated("units/invalid", req, ValidAdminJwt);
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
+            }
         }
 
         public class UnitDelete : ApiTest

--- a/tests/API/Integration/UnitsTests.cs
+++ b/tests/API/Integration/UnitsTests.cs
@@ -402,7 +402,6 @@ namespace Integration
 
             }
 
-
             [Test]
             public async Task CannotDeleteUnitWithChildren()
             {
@@ -581,6 +580,20 @@ namespace Integration
 
                 // Make sure all BuildingRelationships are intact.
                 AssertEntityCollectionEqual(orig.BuildingRelationships, actual.BuildingRelationships, (o, a) => o.Id == a.Id && o.BuildingId == a.BuildingId, "Not all BuildingRelationships are intact.");
+            }
+
+            [Test]
+            public async Task ReturnsBadRequestWhenUnitIdInvalid()
+            {
+                var resp = await DeleteAuthenticated($"units/invalid");
+                AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+                var issue = await resp.Content.ReadAsAsync<ApiError>();
+
+                Assert.That(issue, Is.Not.Null);
+                Assert.That(issue.Details, Is.EqualTo("(none)"));
+                Assert.That(issue.StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
+                Assert.That(issue.Errors.FirstOrDefault(), Is.EqualTo("Expected unitId to be an integer value"));
             }
 
             private static async Task<Unit> GetUnitAndRelated(Database.PeopleContext db, int unitId)


### PR DESCRIPTION
## ServiceNow Story Number and Description
[STRY0013055 - Bug - Bug - API returns 500 Errors When Passed a String](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=c3da00a91b86e91416c02fc4bd4bcbb7%26sysparm_view=scrum)

## Motivation and Context
This PR fixes an issue where passing a string to a function endpoint that requires an integer would cause the endpoint return a 500 error instead of a 400 error. Our initial endpoint definitions required an int parameter, but did not verify that the value passed into the endpoint was a valid integer value. The result was a 500 error.

This PR updates our endpoint functions to explicitly attempt to convert `id` parameters to integer values before passing them into our internal functions. If the value cannot be converted into an integer, the server will return a 400 (Bad Request) error.

In terms of implementation, I updated our code to make the entry functions accept string values and then attempt to convert the string values into integer values and pass them into internal functions which do the actual work. This block of code from the `Units` endpoint is pretty typical

```csharp
[FunctionName(nameof(Units.UnitsGetOne))]
        [OpenApiOperation(nameof(Units.UnitsGetOne), nameof(Units), Summary = "Find a unit by ID")]
        [OpenApiParameter("unitId", Type = typeof(int), In = ParameterLocation.Path, Required = true, Description = "The ID of the unit record.")]
        [OpenApiResponseWithBody(HttpStatusCode.OK, MediaTypeNames.Application.Json, typeof(UnitResponse))]
        [OpenApiResponseWithBody(HttpStatusCode.NotFound, MediaTypeNames.Application.Json, typeof(ApiError), Description = "No unit was found with the provided ID.")]
        public static Task<IActionResult> UnitsGetOne(
            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "units/{unitId}")] HttpRequest req, string unitId)
            => Utils.ConvertParam(unitId, nameof(unitId))
                .Bind(id => UnitsGetOneInternal(req, id))
                .Finally(result => Response.Ok(req, result));

        private static Task<Result<Unit, Error>> UnitsGetOneInternal(HttpRequest req, int unitId)
            => Security.Authenticate(req)
                .Bind(requestor => AuthorizationRepository.DetermineUnitManagementPermissions(req, requestor, unitId, UnitPermissions.Owner, PermsGroups.GetPut))// Set headers saying what the requestor can do to this unit
                .Bind(_ => UnitsRepository.GetOne(unitId));

```
Here, the public `UnitsGetOne` method takes a string `unitId` argument, attempts to convert it, and, if successful, passes the result of the conversion to the `UnitsGetOneInternal` method, which takes an integer `unitId` value. This two-function structure is a littly clunky, but it allows us to get around the need use (in some cases) the integer id value in subsequent bind statements. There are some exceptions, but for the most part, the internal functions are meant to take an integer id and return either a result of the correct type or an error. The external functions generally handle the processes needed to execute the internal methods and convert the output to a valid response.

In all cases, authorization happens after we attempt to convert the id parameter. In more cases than not, we AuthorizationRepository immediately after calling the `Authenticate` method. The `AuthorizationRepository` methods require both the user from the `Authorization` call and the converted id perameter and there's not really an easy way to keep both at the same time in the bind chain, if this makes sense.

## How was this tested?

* Confirmed behavior on local machine
* Confirmed behavior on test server
* Added integration tests