### PR TITLE
STRY0013490: Update Postgres Container to use new version (14.8.0) image

### DIFF
--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -10,7 +10,7 @@ namespace Integration
     public class PostgresContainer : DatabaseContainer
     {
         public PostgresContainer(TextWriter progress, TextWriter error) 
-            : base(progress, error, "postgres:14.7-alpine")
+            : base(progress, error, "postgres:14.8-alpine")
         {
         }
 


### PR DESCRIPTION
[STRY0013490 - Update Postgres Container to use new version (14.8.0) image](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=54eda97e477b2d909286dfbd436d437d%26sysparm_view=scrum)

Quick PR to update the integration tests container to test against the 14.8.0 Postgres database image. This is in preparation for the upcoming database server update to Postgres 14.8.0.