### PR TITLE
INC1339853 - Postgres Quarterly Patching

### DIFF
--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -10,7 +10,7 @@ namespace Integration
     public class PostgresContainer : DatabaseContainer
     {
         public PostgresContainer(TextWriter progress, TextWriter error) 
-            : base(progress, error, "postgres:14.8-alpine")
+            : base(progress, error, "postgres:14.9-alpine")
         {
         }
 


### PR DESCRIPTION
**Do Not Merge Before August 30**

The Postgres DBAs will be updating the test and production database servers Sunday, August 27 2023, between 00:00 and 01:00 AM to address [CVE-2023-39417](https://www.postgresql.org/support/security/CVE-2023-39417/).

This PR updates the Postgres Docker image used for tests to 14.9 to ensure IT People will keep working after this weekend's emergency patching.