### PR TITLE
Updating Departments Null Checks

### DIFF
--- a/src/Tasks/People.cs
+++ b/src/Tasks/People.cs
@@ -197,13 +197,15 @@ namespace Tasks
                     SELECT DISTINCT hr_department, hr_department_desc
                     FROM hr_people
                     WHERE hr_department IS NOT NULL
+                    AND hr_department_desc IS NOT NULL
                     ON CONFLICT (name)
                     DO NOTHING;
                     -- 2. Update department descriptions 
                     UPDATE departments d
                     SET description = hr_department_desc
                     FROM hr_people hr
-                    WHERE d.name = hr.hr_department"));
+                    WHERE d.name = hr.hr_department
+                    AND hr_department_desc IS NOT NULL"));
 
         /// Update name, location, position of people in directory using new HR data
         /// This should be one *after* departments are updated.

--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -10,7 +10,7 @@ namespace Integration
     public class PostgresContainer : DatabaseContainer
     {
         public PostgresContainer(TextWriter progress, TextWriter error) 
-            : base(progress, error, "postgres:14.8-alpine")
+            : base(progress, error, "postgres:14.9-alpine")
         {
         }
 


### PR DESCRIPTION
## ServiceNow Incident
[INC1394692](https://servicenow.iu.edu/nav_to.do?uri=incident.do?sys_id=b7ea52e74795b1d0e06785e8536d438e) - UpdateDepartmentRecords Task Failing

## Context
Today we received alerts about the `UpdateDepartmentRecords` task failing on test.  Some fresh data from the IMS Profile API resulted in an entry in the `hr_people` table that had a valid `hr_department`, but `hr_department_desc` was null.  Which caused `UpdateDepartmentRecords` to fail because `departments.description` cannot be null.

This PR adds null checks that will prevent a scenario where it tries to INSERT or UPDATE a department record with a null `description`.