### PR TITLE
People Export CSV Button Not Working

### DIFF
--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -205,7 +205,7 @@
 			builder.AppendLine(person.AsCsvRow);
 		}
 		await JSRuntime.InvokeVoidAsync("saveAsFile", Person.CsvFileName,
-		System.Text.Encoding.UTF8.GetBytes(builder.ToString()));
+		Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(builder.ToString())));
 	}
 
 	public void Dispose() { }


### PR DESCRIPTION
## ServiceNow Story Number and Description
[STRY0013738](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=1f05abce4706f510e06785e8536d4393%26sysparm_view=scrum) -  Bug - People Export CSV Button Not Working

## Motivation and Context
The "Export results to CSV" button on the `/people` page was failing because it was using an incorrect encoding.  I cribbed the correct values from the UCMP project.  Now the button works.

## How was this tested?
Tested locally and in test environment.
