### PR TITLE
Style to enhance contrast for the version-stamp and pre/code elements.

### DIFF
--- a/src/Web/Pages/Privacy.razor
+++ b/src/Web/Pages/Privacy.razor
@@ -1,0 +1,63 @@
+@using Microsoft.AspNetCore.Components.Web.Extensions.Head
+@using web.Shared
+@page "/Privacy"
+
+<Title Value="Privacy - IT People - Indiana University" />
+<HeaderNavBar Page="Privacy" />
+
+<div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">
+	<h1>IT People Privacy</h1>
+	<h2>Overview</h2>
+	<p>At Indiana University (IU), we are committed to protecting the privacy and confidentiality of personal information
+		entrusted to us. By accessing and using IU's services, you acknowledge and consent to the practices described in our
+		global privacy statement here: <a
+			href=https://privacy.iu.edu/privacy/global.html>https://privacy.iu.edu/privacy/global.html</a>.</p>
+	<p>For additional information outlining how University Information Policy Office collects, uses, and safeguards personal
+		information obtained specifically through our website (<a
+			href=https://datamanagement.iu.edu>https://datamanagement.iu.edu/</a>), please also review the information
+		below.</p>
+	<p>Continued use of our website indicates consent to the collection, use, and disclosure of this information as
+		described in this notice.</p>
+	<p>Visitors to other IU websites should review the privacy notices for the sites they visit, as other units at the
+		university may collect and use visitor information in different ways. University Information Policy Office is not
+		responsible for the content of other websites or for the privacy practices of websites outside the scope of this
+		notice.</p>
+	<h2>Changes</h2>
+	<p>Because Internet technologies continue to evolve rapidly, Service Management Technologies may make appropriate
+		changes to this notice in the future. Any such changes will be consistent with our commitment to respecting visitor
+		privacy, and will be clearly posted in a revised privacy notice.</p>
+	<h2>Collection and Use</h2>
+	<h3>Active/Manual/Voluntary Collection</h3>
+	<p>We will not attempt to collect any information from you through the use of forms or other type of manual input.</p>
+	<h3>Information Sharing</h3>
+	<p>Except as described in the <a href='https://privacy.iu.edu/privacy/global.html'>IU Privacy statement</a>, we will not
+		share any information with any other entities or organizations for any reason.</p>
+	<p>Except as provided in the Disclosure of Information section below, we do not attempt to use the technical information
+		discussed in this section to identify individual visitors.</p>
+	<h3>Cookies</h3>
+	<p>For more information on how we use cookies, please review the <a href='https://privacy.iu.edu/privacy/global.html'>IU
+			Privacy statement</a>.</p>
+	<h3>Use of Third Party Services</h3>
+	<p>Our website does not utilize web analytics services beyond what is noted in the <a
+			href='https://privacy.iu.edu/privacy/global.html'>IU Privacy statement</a>.</p>
+	<h2> Security </h2>
+	<p>Due to the rapidly evolving nature of information technologies, no transmission of information over the Internet can
+		be guaranteed to be completely secure. While Indiana University is committed to protecting user privacy, IU cannot
+		guarantee the security of any information users transmit to university sites, and users do so at their own risk.</p>
+	<h2>Links to non-university sites</h2>
+	<p>Indiana University is not responsible for the availability, content, or privacy practices of non-university sites.
+		Non-university sites are not bound by this site privacy notice policy and may or may not have their own privacy
+		policies.</p>
+	<h2>Privacy Notice Changes</h2>
+	<p>From time to time, we may use visitor information for new, unanticipated uses not previously disclosed in our privacy
+		notice.</p>
+	<h2>Contact Information</h2>
+	<p>If you have questions or concerns about this policy, please contact us.</p>
+	<div>
+		<p></p>
+	</div>
+	<p>If you feel that this site is not following its stated policy and communicating with the owner of this site does not
+		resolve the matter, or if you have general questions or concerns about privacy or information technology policy at
+		Indiana University, please contact the chief privacy officer through the University Information Policy Office,
+		812-855-UIPO, <a href="mailto:privacy@iu.edu">privacy@iu.edu</a>.</p>
+</div>

--- a/src/Web/wwwroot/swagger-ui/cssd.css
+++ b/src/Web/wwwroot/swagger-ui/cssd.css
@@ -41,3 +41,12 @@ a.skip:focus {
 	width: auto;
 	height: auto;
 }
+
+.swagger-ui .info .title small.version-stamp {
+	background-color: #595959 !important;
+}
+
+.swagger-ui .markdown code, .swagger-ui .renderedMarkdown code {
+	background-color: #242424 !important;
+	color: #FDB55E !important;
+}


### PR DESCRIPTION
## ServiceNow Story Number and Description
[STRY0013717](https://iu.service-now.com/nav_to.do?uri=rm_story.do?sys_id=c22dc83347a1bd909286dfbd436d435f%26sysparm_view=scrum) - API Documentation Accessibility Issues

## Motivation and Context
This is a follow-up to #109.  A subsequent scan pointed out two more styles that have contrast that is too low.

## How was this tested?
This PR will deploy to the test environment, where we can confirm the updated styles are working correctly.

## Screenshots
The version has become high-contrast gray
![image](https://github.com/indiana-university/itpeople-functions-v2/assets/12755542/7fff640d-9136-484a-bfe3-6ba0e04337a7)

The `<code>` elements now looks like an old orange monochrome monitor.
![image](https://github.com/indiana-university/itpeople-functions-v2/assets/12755542/8b2efb5e-7ca1-4756-8c2c-f15fc2306744)

