### PR TITLE
Bug: Some Serilog Operations Fail Silently

### DIFF
--- a/pact/StateServer/StateServer.csproj
+++ b/pact/StateServer/StateServer.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
 
 variables:
-  agentPool: 'CSSD-Linux-ELA'
+  agentPool: 'Default'
   NUGET_PACKAGES: '/opt/cssd/nuget'
 
 resources:

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -17,6 +17,7 @@ resources:
 stages:
 - stage: Test
   displayName: Test
+  continueOnError: false
   pool: $(agentPool)
 
   jobs: 
@@ -54,6 +55,7 @@ stages:
 - stage: Package
   displayName: Package  
   dependsOn: []    # this removes the implicit dependency on Test stage and causes this to run in parallel
+  continueOnError: false
   pool: $(agentPool)
 
   jobs:

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -17,7 +17,6 @@ resources:
 stages:
 - stage: Test
   displayName: Test
-  continueOnError: false
   pool: $(agentPool)
 
   jobs: 
@@ -45,7 +44,6 @@ stages:
     
     - task: CmdLine@2
       displayName: Prune old Docker images and cache
-      continueOnError: true # If this task fails keep on truckin'. It's just house keeping
       inputs:
         script: |
           docker image prune --filter "until=48h" --force
@@ -55,7 +53,6 @@ stages:
 - stage: Package
   displayName: Package  
   dependsOn: []    # this removes the implicit dependency on Test stage and causes this to run in parallel
-  continueOnError: false
   pool: $(agentPool)
 
   jobs:
@@ -142,8 +139,6 @@ stages:
 - stage: Deploy
   displayName: Deploy
   pool: $(agentPool)
-  # Deploy if this is not a feature branch, or if the commit message contains '/deploy'
-  condition: or( not( contains( variables['Build.SourceBranch'], 'feature/' )), contains( variables['Build.SourceVersionMessage'], '/deploy' ) )
   dependsOn: 
     - Test
     - Package

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
 
 variables:
-  agentPool: 'Default'
+  agentPool: 'Azure Pipelines'
   NUGET_PACKAGES: '/opt/cssd/nuget'
 
 resources:

--- a/pipelines/azure-pipelines-template.yml
+++ b/pipelines/azure-pipelines-template.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
 
 variables:
-  agentPool: 'Azure Pipelines'
+  agentPool: 'CSSD-Linux-ELA'
   NUGET_PACKAGES: '/opt/cssd/nuget'
 
 resources:

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -21,15 +21,16 @@
 
     <!-- from old API -->
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.38.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="jose-jwt" Version="4.1.0" />
     <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.PostgreSQL" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.Postgresql.Alternative" Version="4.0.4" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <!-- more isolation -->
   <ItemGroup>

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -21,7 +21,6 @@ namespace API.Functions
                 .Bind(requestor => AuthorizationRepository.DetermineServiceAdminPermissions(req, requestor))
                 .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
                 .Bind(_ => InduceException())
-                // .Finally(error => Response.StatusCodeResponse(req, System.Net.HttpStatusCode.InternalServerError));
                 .Finally(error => Response.NoContent(req, error));
         
         private static Result<string, Error> InduceException() => Pipeline.InternalServerError($"From {nameof(ExerciseLogger)}", new System.Exception($"A manually created exception for the ExercixeLogger function."));

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -5,6 +5,7 @@ using API.Middleware;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using API.Data;
+using System.Threading;
 
 namespace API.Functions
 {
@@ -12,8 +13,12 @@ namespace API.Functions
     {
         [Function(nameof(HealthCheck.Ping))]
         public static Task<IActionResult> Ping(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req) 
-                => Response.Ok(req, Pipeline.Success("Pong!"));
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req, CancellationToken hostCancellationToken) 
+		{
+			using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken, req.HttpContext.RequestAborted);
+			cancellationSource.Token.ThrowIfCancellationRequested();
+			return Response.Ok(req, Pipeline.Success("Pong!"));
+		}
         
         [Function(nameof(HealthCheck.ExerciseLogger))]
         public static Task<IActionResult> ExerciseLogger([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ExerciseLogger")] HttpRequest req)

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -12,17 +12,17 @@ namespace API.Functions
     public static class HealthCheck
     {
         [Function(nameof(HealthCheck.Ping))]
-        public static Task<IActionResult> Ping(
+        public static async Task<IActionResult> Ping(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req, CancellationToken hostCancellationToken) 
 		{
 			using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken, req.HttpContext.RequestAborted);
 			cancellationSource.Token.ThrowIfCancellationRequested();
-			return Response.Ok(req, Pipeline.Success("Pong!"));
+			return await Response.Ok(req, Pipeline.Success("Pong!"));
 		}
         
         [Function(nameof(HealthCheck.ExerciseLogger))]
-        public static Task<IActionResult> ExerciseLogger([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ExerciseLogger")] HttpRequest req)
-            => Security.Authenticate(req)
+        public static async Task<IActionResult> ExerciseLogger([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ExerciseLogger")] HttpRequest req)
+            => await Security.Authenticate(req)
                 .Bind(requestor => AuthorizationRepository.DetermineServiceAdminPermissions(req, requestor))
                 .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
                 .Bind(_ => InduceException())

--- a/src/API/Functions/Healthcheck.cs
+++ b/src/API/Functions/Healthcheck.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using API.Middleware;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using API.Data;
 
 namespace API.Functions
 {
@@ -12,5 +14,16 @@ namespace API.Functions
         public static Task<IActionResult> Ping(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ping")] HttpRequest req) 
                 => Response.Ok(req, Pipeline.Success("Pong!"));
+        
+        [Function(nameof(HealthCheck.ExerciseLogger))]
+        public static Task<IActionResult> ExerciseLogger([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ExerciseLogger")] HttpRequest req)
+            => Security.Authenticate(req)
+                .Bind(requestor => AuthorizationRepository.DetermineServiceAdminPermissions(req, requestor))
+                .Bind(perms => AuthorizationRepository.AuthorizeModification(perms))
+                .Bind(_ => InduceException())
+                // .Finally(error => Response.StatusCodeResponse(req, System.Net.HttpStatusCode.InternalServerError));
+                .Finally(error => Response.NoContent(req, error));
+        
+        private static Result<string, Error> InduceException() => Pipeline.InternalServerError($"From {nameof(ExerciseLogger)}", new System.Exception($"A manually created exception for the ExercixeLogger function."));
     }
 }

--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -99,23 +99,14 @@ namespace API.Middleware
                 ? (DateTime.UtcNow - (DateTime)req.HttpContext.Items[LogProps.ElapsedTime]).TotalMilliseconds
                 : -1;
 
-            // return Logger
-            //     .ForContext(LogProps.ElapsedTime, elapsed)
-            //     .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
-            //     .ForContext(LogProps.RequestMethod, req.Method)
-            //     .ForContext(LogProps.Function, pathParts.FirstOrDefault())
-            //     .ForContext(LogProps.RequestParameters, string.Join('/', pathParts.Skip(1)))
-            //     .ForContext(LogProps.RequestQuery, req.QueryString)
-            //     .ForContext(LogProps.RequestorNetid, req.HttpContext.Items[LogProps.RequestorNetid]);
-
             return Logger
-                .ForContext(LogProps.ElapsedTime, 69)
-                .ForContext(LogProps.RequestIPAddress, "66.170.44.10")
-                .ForContext(LogProps.RequestMethod, "PUT")
-                .ForContext(LogProps.Function, "bullshit")
-                .ForContext(LogProps.RequestParameters, string.Empty)
-                .ForContext(LogProps.RequestQuery, string.Empty)
-                .ForContext(LogProps.RequestorNetid, "billy");
+                .ForContext(LogProps.ElapsedTime, elapsed)
+                .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
+                .ForContext(LogProps.RequestMethod, req.Method)
+                .ForContext(LogProps.Function, pathParts.FirstOrDefault())
+                .ForContext(LogProps.RequestParameters, string.Join('/', pathParts.Skip(1)))
+                .ForContext(LogProps.RequestQuery, req.QueryString)
+                .ForContext(LogProps.RequestorNetid, req.HttpContext.Items[LogProps.RequestorNetid]);
         }
     }
 }

--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -99,14 +99,23 @@ namespace API.Middleware
                 ? (DateTime.UtcNow - (DateTime)req.HttpContext.Items[LogProps.ElapsedTime]).TotalMilliseconds
                 : -1;
 
+            // return Logger
+            //     .ForContext(LogProps.ElapsedTime, elapsed)
+            //     .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
+            //     .ForContext(LogProps.RequestMethod, req.Method)
+            //     .ForContext(LogProps.Function, pathParts.FirstOrDefault())
+            //     .ForContext(LogProps.RequestParameters, string.Join('/', pathParts.Skip(1)))
+            //     .ForContext(LogProps.RequestQuery, req.QueryString)
+            //     .ForContext(LogProps.RequestorNetid, req.HttpContext.Items[LogProps.RequestorNetid]);
+
             return Logger
-                .ForContext(LogProps.ElapsedTime, elapsed)
-                .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
-                .ForContext(LogProps.RequestMethod, req.Method)
-                .ForContext(LogProps.Function, pathParts.FirstOrDefault())
-                .ForContext(LogProps.RequestParameters, string.Join('/', pathParts.Skip(1)))
-                .ForContext(LogProps.RequestQuery, req.QueryString)
-                .ForContext(LogProps.RequestorNetid, req.HttpContext.Items[LogProps.RequestorNetid]);
+                .ForContext(LogProps.ElapsedTime, 69)
+                .ForContext(LogProps.RequestIPAddress, "66.170.44.10")
+                .ForContext(LogProps.RequestMethod, "PUT")
+                .ForContext(LogProps.Function, "bullshit")
+                .ForContext(LogProps.RequestParameters, string.Empty)
+                .ForContext(LogProps.RequestQuery, string.Empty)
+                .ForContext(LogProps.RequestorNetid, "billy");
         }
     }
 }

--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -6,6 +6,7 @@ using Serilog.Sinks.PostgreSQL;
 using NpgsqlTypes;
 using System.Linq;
 using System;
+using Serilog.Sinks.PostgreSQL.ColumnWriters;
 
 namespace API.Middleware
 {
@@ -75,16 +76,17 @@ namespace API.Middleware
                 logger.WriteTo.PostgreSQL(
                     connectionString, tableName, columnWriters);
             }
+
             return logger;
         }
 
-        private static Lazy<ILogger> Logger = new Lazy<ILogger>(() => 
+        public static LoggerConfiguration LoggerConfig =>
             new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .TryAddAzureAppInsightsSink()
-                .TryAddPostgresqlDatabaseSink()
-                .CreateLogger());
+                .TryAddPostgresqlDatabaseSink();
+        private static ILogger Logger => LoggerConfig.CreateLogger();
 
         public static ILogger GetLogger(HttpRequest req)
         {
@@ -97,7 +99,7 @@ namespace API.Middleware
                 ? (DateTime.UtcNow - (DateTime)req.HttpContext.Items[LogProps.ElapsedTime]).TotalMilliseconds
                 : -1;
 
-            return Logger.Value
+            return Logger
                 .ForContext(LogProps.ElapsedTime, elapsed)
                 .ForContext(LogProps.RequestIPAddress, req.HttpContext.Connection.RemoteIpAddress)
                 .ForContext(LogProps.RequestMethod, req.Method)

--- a/src/API/Middleware/Request.cs
+++ b/src/API/Middleware/Request.cs
@@ -24,6 +24,9 @@ namespace API.Middleware
             {
                 var json = await req.ReadAsStringAsync();
                 var body = JsonConvert.DeserializeObject<T>(json);
+                
+                // Stash the json for use later in the pipeline.
+                req.HttpContext.Items[LogProps.RequestBody] = json;
                 return Pipeline.Success(body);
             }
             catch (Exception ex)

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -153,7 +153,6 @@ namespace API.Middleware
             var errorsString = JsonConvert.SerializeObject(new List<string>(), Json.JsonSerializerSettings);
 
             requestBody = null;
-            recordBody = null;
 
             try
             {
@@ -178,7 +177,6 @@ namespace API.Middleware
             var errorsString = JsonConvert.SerializeObject(error.Messages, Json.JsonSerializerSettings);
             
             requestBody = null;
-            recBody = null;
             
             logger
                 .ForContext(LogProps.StatusCode, (int)error.StatusCode)

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -36,9 +36,8 @@ namespace API.Middleware
             {
                 if (IsGetMethod(req) == false || IsLspFunction(req) == true)
                 {
-                    // await Logging.GetLogger(req).SuccessResult<T>(req, statusCode);
-                    // await Logging.GetLogger(req).FailureResult<T>(req, new Error(HttpStatusCode.Conflict, "WTF?", new Exception("FAKE EXCEPTION")));
-                    await logger.FailureResult<T>(req, new Error(HttpStatusCode.Conflict, "WTF?", new Exception("FAKE EXCEPTION")));
+                    await Logging.GetLogger(req).SuccessResult<T>(req, statusCode);
+                    // await logger.FailureResult<T>(req, new Error(HttpStatusCode.Conflict, "WTF?", new Exception("FAKE EXCEPTION")));
                 }
                 return resultGenerator(result.Value);
             }
@@ -151,14 +150,18 @@ namespace API.Middleware
         {
             var requestBody = request.ContentLength > 0 ? await request.ReadAsStringAsync() : null;
             var recordBody = request.HttpContext.Items[LogProps.RecordBody];
+            var errorsString = JsonConvert.SerializeObject(new List<string>(), Json.JsonSerializerSettings);
+
+            requestBody = null;
+            recordBody = null;
+
             try
             {
                 logger
                     .ForContext(LogProps.StatusCode, (int)statusCode)
                     .ForContext(LogProps.RequestBody, requestBody)
-                    // .ForContext(LogProps.RecordBody, recordBody)
-                    .ForContext(LogProps.RecordBody, string.Empty)
-                    .ForContext(LogProps.ErrorMessages, JsonConvert.SerializeObject(new List<string>(), Json.JsonSerializerSettings))
+                    .ForContext(LogProps.RecordBody, recordBody)
+                    .ForContext(LogProps.ErrorMessages, errorsString)
                     .Information($"[{{{LogProps.StatusCode}}}] {{{LogProps.RequestorNetid}}} - {{{LogProps.RequestMethod}}} {{{LogProps.Function}}}{{{LogProps.RequestParameters}}}{{{LogProps.RequestQuery}}}");
             }
             catch(Exception ex)

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -36,14 +36,12 @@ namespace API.Middleware
             {
                 if (IsGetMethod(req) == false || IsLspFunction(req) == true)
                 {
-                    await Logging.GetLogger(req).SuccessResult<T>(req, statusCode);
-                    // await logger.FailureResult<T>(req, new Error(HttpStatusCode.Conflict, "WTF?", new Exception("FAKE EXCEPTION")));
+                    await logger.SuccessResult<T>(req, statusCode);
                 }
                 return resultGenerator(result.Value);
             }
             else
             {
-                // await Logging.GetLogger(req).FailureResult<T>(req, result.Error);
                 await logger.FailureResult<T>(req, result.Error);
                 return result.Error.ToResponse(req);
             }
@@ -156,7 +154,7 @@ namespace API.Middleware
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        private static string? GetRequestBody(HttpRequest request)
+        private static string GetRequestBody(HttpRequest request)
         {
             var requestBody = request.HttpContext.Items[LogProps.RequestBody]?.ToString();
             // Ensure this is valid json, if it isn't return null.

--- a/src/API/Middleware/Response.cs
+++ b/src/API/Middleware/Response.cs
@@ -36,7 +36,7 @@ namespace API.Middleware
             {
                 if (IsGetMethod(req) == false || IsLspFunction(req) == true)
                 {
-                    await logger.SuccessResult<T>(req, statusCode);
+                    await logger.SuccessResult(req, statusCode);
                 }
                 return resultGenerator(result.Value);
             }
@@ -173,7 +173,7 @@ namespace API.Middleware
             return requestBody;
         }
 
-        private static async Task SuccessResult<T>(this Serilog.ILogger logger, HttpRequest request, HttpStatusCode statusCode)
+        private static async Task SuccessResult(this Serilog.ILogger logger, HttpRequest request, HttpStatusCode statusCode)
         {
             var requestBody = GetRequestBody(request);
             var recordBody = request.HttpContext.Items[LogProps.RecordBody];

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -23,7 +23,7 @@ namespace API
                     var loggerConfig = Logging.LoggerConfig;
                     var logger = loggerConfig.CreateLogger();
 
-                    services.AddLogging(l => l.AddSerilog(logger));
+                    // services.AddLogging(l => l.AddSerilog(logger));
                 })
                 .Build();
 

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using Database;
 using System.Threading.Tasks;
-using API.Middleware;
-using Serilog;
 
 namespace API
 {
@@ -19,11 +17,6 @@ namespace API
                 .ConfigureServices(services => {
                     services.AddApplicationInsightsTelemetryWorkerService();
                     services.ConfigureFunctionsApplicationInsights();
-
-                    var loggerConfig = Logging.LoggerConfig;
-                    var logger = loggerConfig.CreateLogger();
-
-                    // services.AddLogging(l => l.AddSerilog(logger));
                 })
                 .Build();
 

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using Database;
 using System.Threading.Tasks;
+using API.Middleware;
+using Serilog;
 
 namespace API
 {
@@ -17,6 +19,11 @@ namespace API
                 .ConfigureServices(services => {
                     services.AddApplicationInsightsTelemetryWorkerService();
                     services.ConfigureFunctionsApplicationInsights();
+
+                    var loggerConfig = Logging.LoggerConfig;
+                    var logger = loggerConfig.CreateLogger();
+
+                    services.AddLogging(l => l.AddSerilog(logger));
                 })
                 .Build();
 

--- a/src/API/host.json
+++ b/src/API/host.json
@@ -3,7 +3,7 @@
     "logging": {
         "applicationInsights": {
             "samplingSettings": {
-                "isEnabled": false,
+                "isEnabled": true,
                 "excludedTypes": "Request"
             }
         }

--- a/src/API/host.json
+++ b/src/API/host.json
@@ -3,7 +3,7 @@
     "logging": {
         "applicationInsights": {
             "samplingSettings": {
-                "isEnabled": true,
+                "isEnabled": false,
                 "excludedTypes": "Request"
             }
         }

--- a/src/Database/Database.csproj
+++ b/src/Database/Database.csproj
@@ -4,15 +4,15 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.15">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />
-    <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Models\Models.csproj" />

--- a/src/Tasks/Logging.cs
+++ b/src/Tasks/Logging.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Serilog.Events;
 using System;
 using Microsoft.DurableTask;
+using Serilog.Sinks.PostgreSQL.ColumnWriters;
 
 namespace Tasks
 {

--- a/src/Tasks/Tasks.csproj
+++ b/src/Tasks/Tasks.csproj
@@ -10,12 +10,12 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.PostgreSQL" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.Postgresql.Alternative" Version="4.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/API/Integration/Integration.csproj
+++ b/tests/API/Integration/Integration.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PactNet" Version="2.6.1" />
     <PackageReference Include="PactNet.Linux.x64" Version="2.6.1" />

--- a/tests/API/Integration/LoggingTests.cs
+++ b/tests/API/Integration/LoggingTests.cs
@@ -124,8 +124,10 @@ namespace Integration
 		[Test]
 		public async Task ExceptoinsAreLogged()
 		{
-			var resp = await PostAuthenticated("units", "this isn't JSON, it's gibberish.", ValidAdminJwt);
-			AssertStatusCode(resp, HttpStatusCode.BadRequest);
+			// Try to induce an error that should record an exception
+			var badUnit = DeepCopy(TestEntities.Units.ParksAndRecUnit);
+			badUnit.Id = 999;
+			var resp = await GetAuthenticated("ExerciseLogger", ValidAdminJwt);
 
 			// Confirm the logs were generated.
 			var logs = await GetAllLogs();

--- a/tests/API/Integration/LoggingTests.cs
+++ b/tests/API/Integration/LoggingTests.cs
@@ -122,7 +122,7 @@ namespace Integration
 		}
 
 		[Test]
-		public async Task ExceptoinsAreLogged()
+		public async Task ExceptionsAreLogged()
 		{
 			// Try to induce an error that should record an exception
 			var resp = await GetAuthenticated("ExerciseLogger", ValidAdminJwt);

--- a/tests/API/Integration/LoggingTests.cs
+++ b/tests/API/Integration/LoggingTests.cs
@@ -96,7 +96,7 @@ namespace Integration
 		public async Task ErrorsAreWellLogged()
 		{
 			// Make a request to POST a unit hat fails.
-			var malformedUnit = TestEntities.Units.CityOfPawnee;
+			var malformedUnit = DeepCopy(TestEntities.Units.CityOfPawnee);
 			malformedUnit.Name = null;
 			var resp = await PostAuthenticated("units", malformedUnit, ValidAdminJwt);
 			AssertStatusCode(resp, HttpStatusCode.BadRequest);

--- a/tests/API/Integration/LoggingTests.cs
+++ b/tests/API/Integration/LoggingTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Database;
+using Microsoft.EntityFrameworkCore;
+using Models;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Integration
+{
+	public class LoggingTests : ApiTest
+	{
+		private class Log
+		{
+			public DateTime Timestamp { get; set; }
+			public string Level { get; set; }
+			public int Elapsed { get; set; }
+			public int Status { get; set; }
+			public string Method { get; set; }
+			public string Function { get; set; }
+			public string Parameters { get; set; }
+			public string Query { get; set; }
+			public string Detail { get; set; }
+			public string Exception { get; set; }
+			[Column("ip_address")]
+			public string IpAddress { get; set; }
+			[Column("netid")]
+			public string NetId { get; set; }
+			public string Content { get; set; }
+			public string Request { get; set; }
+			public string Record { get; set; }
+		}
+
+		private PeopleContext GetDb() => PeopleContext.Create(Database.PeopleContext.LocalDatabaseConnectionString);
+		private async Task<List<Log>> GetAllLogs()
+		{
+			using var db = GetDb();
+			var logs = await db.Database
+				.SqlQuery<Log>($"SELECT \"timestamp\", \"level\", elapsed, \"status\", method, \"function\", parameters, query, detail, \"exception\", ip_address, netid, content, request, record FROM logs")
+				.AsNoTracking()
+				.ToListAsync();
+			
+			return logs;
+		}
+
+		private T DeepCopy<T>(T UpdatedEntity)
+		{
+			return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(UpdatedEntity, Json.JsonSerializerSettings), Json.JsonSerializerSettings);
+		}
+
+		[Test]
+		public async Task MakingUnitInactiveIsLoggedCorrectly()
+		{
+			// Make a new Unit.
+			var uc = new UnitsTests.UnitCreate();
+			await uc.CreateMayorsOffice();
+
+			var logs = await GetAllLogs();
+			Assert.That(logs.Count, Is.EqualTo(1));
+
+			// Get the unit from the DB and then de-activate it.
+			using var db = GetDb();
+			var unit = db.Units.OrderBy(u => u.Id).AsNoTracking().Last();
+			Assert.That(unit.Active, Is.True);
+			
+			var resp = await DeleteAuthenticated($"units/{unit.Id}/archive", ValidAdminJwt);
+			AssertStatusCode(resp, HttpStatusCode.OK);
+
+			// Confirm unit is not active
+			await db.Entry(unit).ReloadAsync();
+			Assert.That(unit.Active, Is.False);
+
+			// Refresh the logs
+			logs = await GetAllLogs();
+			Assert.That(logs.Count, Is.EqualTo(2));
+
+			var lastLog = logs.OrderBy(l => l.Timestamp).Last();
+
+			Assert.That(lastLog.Function, Is.EqualTo("units"));
+			Assert.That(lastLog.Method, Is.EqualTo("DELETE"));
+			Assert.That(lastLog.NetId, Is.EqualTo("johndoe"));
+			Assert.That(lastLog.Parameters, Is.EqualTo($"{unit.Id}/archive"));
+			Assert.That(lastLog.Query, Is.Empty);
+			Assert.That(lastLog.Record, Is.Not.Empty);
+			Assert.That(lastLog.Request, Is.Null);
+			Assert.That(lastLog.Status, Is.EqualTo(200));
+			Assert.That(lastLog.Content, Is.Null);
+			Assert.That(lastLog.Exception, Is.Null);
+		}
+
+		[Test]
+		public async Task ErrorsAreWellLogged()
+		{
+			// Make a request to POST a unit hat fails.
+			var malformedUnit = TestEntities.Units.CityOfPawnee;
+			malformedUnit.Name = null;
+			var resp = await PostAuthenticated("units", malformedUnit, ValidAdminJwt);
+			AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+			// Confirm the logs were generated.
+			var logs = await GetAllLogs();
+			Assert.That(logs.Count, Is.EqualTo(1));
+
+			var log = logs.Single();
+
+			Assert.That(log.Content, Is.Null);
+			Assert.That(log.Detail, Contains.Substring("The request body is malformed or missing. The Name field is required."));
+			Assert.That(log.Exception, Is.Null);
+			Assert.That(log.Function, Is.EqualTo("units"));
+			Assert.That(log.Level, Is.EqualTo("Error"));
+			Assert.That(log.Method, Is.EqualTo("POST"));
+			Assert.That(log.NetId, Is.EqualTo("johndoe"));
+			Assert.That(log.Parameters, Is.Empty);
+			Assert.That(log.Query, Is.Empty);
+			Assert.That(log.Record, Is.Null);
+			Assert.That(log.Request, Is.Not.Null);
+			Assert.That(log.Status, Is.EqualTo(400));
+		}
+
+		[Test]
+		public async Task ExceptoinsAreLogged()
+		{
+			var resp = await PostAuthenticated("units", "this isn't JSON, it's gibberish.", ValidAdminJwt);
+			AssertStatusCode(resp, HttpStatusCode.BadRequest);
+
+			// Confirm the logs were generated.
+			var logs = await GetAllLogs();
+			Assert.That(logs.Count, Is.EqualTo(1));
+
+			var log = logs.Single();
+
+			Assert.That(log.Exception, Is.Not.Null);
+		}
+	}
+}
+

--- a/tests/API/Integration/LoggingTests.cs
+++ b/tests/API/Integration/LoggingTests.cs
@@ -125,8 +125,6 @@ namespace Integration
 		public async Task ExceptoinsAreLogged()
 		{
 			// Try to induce an error that should record an exception
-			var badUnit = DeepCopy(TestEntities.Units.ParksAndRecUnit);
-			badUnit.Id = 999;
 			var resp = await GetAuthenticated("ExerciseLogger", ValidAdminJwt);
 
 			// Confirm the logs were generated.

--- a/tests/API/Integration/Scaffolding/DockerContainer.cs
+++ b/tests/API/Integration/Scaffolding/DockerContainer.cs
@@ -29,9 +29,6 @@ namespace Integration
         {           
             Progress.WriteLine($"⏳ Fetching Docker image '{ImageName}'. This can take a long time -- hang in there!");
 
-            // await client.Images.CreateImageAsync(
-            //     new ImagesCreateParameters { FromImage = ImageName }, null, new ConsoleProgress(Progress));
-
             var list = await client.Containers.ListContainersAsync(new ContainersListParameters
             {
                 All = true
@@ -155,6 +152,8 @@ namespace Integration
             {
                 Error.WriteLine($"🤮 Failed to run 'docker {arguments}'.");
             }
+
+            await Task.CompletedTask;
         }
     }
 

--- a/tests/API/Integration/Scaffolding/DockerContainer.cs
+++ b/tests/API/Integration/Scaffolding/DockerContainer.cs
@@ -29,8 +29,8 @@ namespace Integration
         {           
             Progress.WriteLine($"⏳ Fetching Docker image '{ImageName}'. This can take a long time -- hang in there!");
 
-            await client.Images.CreateImageAsync(
-                new ImagesCreateParameters { FromImage = ImageName }, null, new ConsoleProgress(Progress));        
+            // await client.Images.CreateImageAsync(
+            //     new ImagesCreateParameters { FromImage = ImageName }, null, new ConsoleProgress(Progress));
 
             var list = await client.Containers.ListContainersAsync(new ContainersListParameters
             {
@@ -118,7 +118,7 @@ namespace Integration
             return $"{nameof(ImageName)}: {ImageName}, {nameof(ContainerName)}: {ContainerName}";
         }
 
-        protected void DockerExec(string arguments, string workingDirectory)
+        protected async Task DockerExec(string arguments, string workingDirectory)
         {
             var p = new Process()
             {

--- a/tests/API/Integration/Scaffolding/FunctionAppContainer.cs
+++ b/tests/API/Integration/Scaffolding/FunctionAppContainer.cs
@@ -18,10 +18,10 @@ namespace Integration
             Port = port;
         }
 
-        public void BuildImage()
+        public async Task BuildImage()
         {
             Progress.WriteLine($"⏳ Building Function App image '{ImageName}'. This can take some time -- hang in there!");
-            DockerExec($"build --pull --rm --file {DockerFile} --tag {ImageName} .", "../../../../../../");
+            await DockerExec($"build --pull --rm --file {DockerFile} --tag {ImageName} .", "../../../../../../");
         }
 
 

--- a/tests/API/Integration/Scaffolding/Harness.cs
+++ b/tests/API/Integration/Scaffolding/Harness.cs
@@ -41,14 +41,14 @@ namespace Integration
 
             try { AppContainer.Remove(_client).Wait(60*1000); } catch {}
             // Build and start API Function app container
-            AppContainer.BuildImage();
+            AppContainer.BuildImage().Wait();
             AppContainer.Start(_client).Wait();
             // Wait for API container to finish starting
             AppContainer.WaitUntilReady().Wait();
 
             try { StateContainer.Remove(_client).Wait(60*1000); } catch {}
             // Build and start API Function app container
-            StateContainer.BuildImage();
+            StateContainer.BuildImage().Wait();
             StateContainer.Start(_client).Wait();
             // Wait for API container to finish starting
             StateContainer.WaitUntilReady().Wait();

--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -16,7 +16,7 @@ namespace Integration
 
         public void Pull()
         {
-            DockerExec($"pull {ImageName}", ".");
+            DockerExec($"pull {ImageName}", ".").Wait();
         }
 
         public override Config ToConfig() 


### PR DESCRIPTION
## ServiceNow Story Number and Description
A bug in the logging services was discovered while attempting to address [INC1831717](https://servicenow.iu.edu/nav_to.do?uri=incident.do?sys_id=a646645e476e0ad0e06785e8536d431b).

## Motivation and Context
When IT People was pulled-up to .Net 8 in #113  our PostgreSQL SeriLog sink started failing silently for most POST and PUT requests.  This was because the `LogProps.RequestBody` `ColumnWriter` uses the `NpgsqlDbType.Json`, which blows up when it receives a value that is not `null` or well-formed JSON.  With the upgrade to .Net 8 `LogProps.RequestBody` would often be provided an empty string which would cause the DB `INSERT` to fail. More on this later.

## How was this tested?
Manually testing this locally was **hard** because it was failing silently, but with a combination of `func start --dotnet-isolated-debug`, Postman, and querying the latest logs to see the results of
```pgsql
SELECT *
FROM logs
WHERE "timestamp" > NOW() - INTERVAL '5 minutes'
```
Then I added `LoggingTests` to automate that leg work, and catch future regressions like this.

## Substantive Changes
**Exercise Logger**
Our error-handling is pretty good, so when I wanted to ensure `Exceptions` were being logged correctly it proved very difficult to induce an error that was not "handled."  So I added `HealthCheck.ExerciseLogger()` to add an endpoint, that only site admins can access, to throw a less-well-handled exception to ensure the properties were logged correctly.

**That Sinking Feeling**
The biggest change is moving from the `Serilog.Sinks.Postgresql` NuGet package which is no longer maintained to `Serilog.Sinks.Postgresql.Alternative`.  This also necessitated updating several other EntityFramework and SeriLog packages.

**Being Lazy About Lazy<>**
While struggling to find the core problem I removed the lazy loading operations, thinking they may have issues running in a `dotnet-isolated` function app (`in-process` is not currently supported by .Net 8).  They were not the cause of the problem, but IMO it simplifies things, so I didn't restore them.

**This message with self-destruct in 5 seconds**
The actual cause of the problem was that historically we'd read the request body once for the `Functions` themselves, and then the logger would read the body from the request again.  In .Net 8 `dotnet-isolated` the body of an `HttpRequest` is now a one-time read.   That meant when the logger tried to re-read the request it would get an empty string.  Since this is neither `null` nor well-formed JSON the attempt to insert the log item to the database would fail.

I got around this problem using the same strategy for storing the existing `Record` in the request's `HttpContext.Items` by making `Request.TryDeserializeBody()` store the JSON it reads to in the items, as well. Then when it's time for the logger to try to get the request body it calls `Response.GetRequestBody()` to read and validate the copy we stored in `HttpContext.Items`. This ensures the INSERT does not fail.

**Hold Your Horses**
While grasping at straws I ended up fixing several async/await/.Wait() issues around how the integration tests build and launch Docker images and containers.  I also found a place where some operations were being performed more than once, so we also get a small improvement in the start-up time before its actually running tests.
