### PR TITLE
App insights update

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
 
     <!-- for isolation replaces Microsoft.Azure.WebJobs.Extensions.Storage -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.3.0" />

--- a/src/API/Middleware/Logging.cs
+++ b/src/API/Middleware/Logging.cs
@@ -37,7 +37,7 @@ namespace API.Middleware
     {
         private static LoggerConfiguration TryAddAzureAppInsightsSink(this LoggerConfiguration logger)
         {
-            var appInsightsKey = Utils.Env("APPINSIGHTS_INSTRUMENTATIONKEY");
+            var appInsightsKey = Utils.Env("APPLICATIONINSIGHTS_CONNECTION_STRING");
             if (!string.IsNullOrWhiteSpace(appInsightsKey))
             {
                 logger.WriteTo.ApplicationInsights(

--- a/src/Tasks/Logging.cs
+++ b/src/Tasks/Logging.cs
@@ -25,7 +25,7 @@ namespace Tasks
         {
             try
             {
-                var appInsightsKey = Utils.Env("APPINSIGHTS_INSTRUMENTATIONKEY");
+                var appInsightsKey = Utils.Env("APPLICATIONINSIGHTS_CONNECTION_STRING");
                 if (!string.IsNullOrWhiteSpace(appInsightsKey))
                 {
                     logger.WriteTo.ApplicationInsights(

--- a/src/Tasks/local.settings.example.json
+++ b/src/Tasks/local.settings.example.json
@@ -14,6 +14,6 @@
         "AdToolsGroupManagerUser":"a username",
         "AdToolsGroupManagerPassword":"password for AdUser",
         "DatabaseConnectionString":"Server=localhost;Database=ItPeople;User Id=SA;Password=abcd1234@;",
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "an App Insights instrumentation key (guid)"
+        "APPLICATIONINSIGHTS_CONNECTION_STRING": "an App Insights connection string"
     }
 }


### PR DESCRIPTION
## ServiceNow Story Number and Description
[INC2379873](https://servicenow.iu.edu/nav_to.do?uri=incident.do?sys_id=ca09149f47942a54d500b87b716d432c) - Application Insights Deprecates Instrumentation Keys

## Motivation and Context
Azure is transitioning Application Insights from "ingestion keys" to "connection strings". This PR applies those changes.  I updated all the AppInsight packages to latest, and the new connection strings are a drop-in replacement for the old ingestion key.

## How was this tested?
I deployed this work to the test environment and confirmed that the same details were being logged to AppInsights after those deploy.