### PR TITLE
Docker dotnet enhanced

### DIFF
--- a/tests/API/Integration/Integration.csproj
+++ b/tests/API/Integration/Integration.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/API/Integration/Integration.csproj
+++ b/tests/API/Integration/Integration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+    <PackageReference Include="Docker.DotNet.Enhanced" Version="3.131.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/tests/API/Integration/Scaffolding/DockerContainer.cs
+++ b/tests/API/Integration/Scaffolding/DockerContainer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace Integration
 {
@@ -76,12 +77,13 @@ namespace Integration
         private async Task createContainer(IDockerClient client)
         {
             Progress.WriteLine($"⏳ Creating container '{ContainerName}' using image '{ImageName}'");
-            await client.Containers.CreateContainerAsync(new CreateContainerParameters(ToConfig())
+            await client.Containers.CreateContainerAsync(new CreateContainerParameters()
             {
                 Image = ImageName,
                 Name = ContainerName,
                 Tty = true,
                 HostConfig = ToHostConfig(),
+                Env = EnvironmentVariables
             });
         }
 
@@ -108,7 +110,7 @@ namespace Integration
 
         public abstract HostConfig ToHostConfig();
 
-        public abstract Config ToConfig();
+        public abstract List<string> EnvironmentVariables { get;  }
 
         public override string ToString()
         {
@@ -166,7 +168,7 @@ namespace Integration
 
         public void Report(JSONMessage value)
         {
-            _progress.WriteLine(value.ProgressMessage);
+            _progress.WriteLine(value.Status);
         }
     }
 }

--- a/tests/API/Integration/Scaffolding/DockerContainer.cs
+++ b/tests/API/Integration/Scaffolding/DockerContainer.cs
@@ -110,7 +110,7 @@ namespace Integration
 
         public abstract HostConfig ToHostConfig();
 
-        public abstract List<string> EnvironmentVariables { get;  }
+        public abstract List<string> EnvironmentVariables { get; }
 
         public override string ToString()
         {

--- a/tests/API/Integration/Scaffolding/FunctionAppContainer.cs
+++ b/tests/API/Integration/Scaffolding/FunctionAppContainer.cs
@@ -52,18 +52,15 @@ namespace Integration
             }
         }
 
-        public override Config ToConfig() 
-            => new Config
-                {
-                    Env = new List<string> 
-                    {
-                        // Add test-only environment variables here, or
-                        // add them in Dockerfile.API
-                        
-                        // for testing, allow all IPv4 and IPv6 ranges to access
-                        // LSP functions
-                        "LspFuncsAllowedIpRanges=0.0.0.0/0,::/0"
-                    }
+        public override List<string> EnvironmentVariables => 
+            new List<string> 
+            {
+                // Add test-only environment variables here, or
+                // add them in Dockerfile.API
+                
+                // for testing, allow all IPv4 and IPv6 ranges to access
+                // LSP functions
+                "LspFuncsAllowedIpRanges=0.0.0.0/0,::/0"
             };
 
         public override HostConfig ToHostConfig()

--- a/tests/API/Integration/Scaffolding/PostgresContainer.cs
+++ b/tests/API/Integration/Scaffolding/PostgresContainer.cs
@@ -19,15 +19,12 @@ namespace Integration
             DockerExec($"pull {ImageName}", ".");
         }
 
-        public override Config ToConfig() 
-            => new Config
-            {
-                Env = new List<string> 
-                { 
+        public override List<string> EnvironmentVariables =>
+            new List<string>
+                {
                     "POSTGRES_USER=SA",
                     "POSTGRES_PASSWORD=abcd1234@",
-                }
-            };
+                };
 
         // Watch the port mapping here to avoid port
         // contention w/ other Sql Server installations

--- a/tests/API/Integration/Scaffolding/SqlServerContainer.cs
+++ b/tests/API/Integration/Scaffolding/SqlServerContainer.cs
@@ -38,11 +38,8 @@ namespace Integration
                     },
             };
 
-        public override Config ToConfig() 
-            => new Config
-            {
-                Env = new List<string> { "ACCEPT_EULA=Y", "SA_PASSWORD=abcd1234@", "MSSQL_PID=Developer" }
-            };
+        public override List<string> EnvironmentVariables =>
+            new List<string> { "ACCEPT_EULA=Y", "SA_PASSWORD=abcd1234@", "MSSQL_PID=Developer" };
 
         protected override DbConnection GetConnection() 
             => new SqlConnection(PeopleContext.LocalServerConnectionString);

--- a/tests/API/Integration/Scaffolding/SqlServerContainer.cs
+++ b/tests/API/Integration/Scaffolding/SqlServerContainer.cs
@@ -1,4 +1,4 @@
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Docker.DotNet.Models;
 using System.IO;
 using System.Collections.Generic;

--- a/tests/API/Integration/Scaffolding/SqlServerContainer.cs
+++ b/tests/API/Integration/Scaffolding/SqlServerContainer.cs
@@ -41,7 +41,7 @@ namespace Integration
         public override List<string> EnvironmentVariables =>
             new List<string> { "ACCEPT_EULA=Y", "SA_PASSWORD=abcd1234@", "MSSQL_PID=Developer" };
 
-        protected override DbConnection GetConnection() 
+        protected override DbConnection GetConnection()
             => new SqlConnection(PeopleContext.LocalServerConnectionString);
     }
 }


### PR DESCRIPTION
## Motivation and Context
Our build agents updated to Docker Engine 29 [chage log](https://www.docker.com/blog/docker-engine-version-29/) which has some kind of breaking change for the old [Docker.DotNet](https://github.com/dotnet/Docker.DotNet) package we use to wrangle containers in integration tests. Sadly that package hasn't seen an update since 2023.

The fine folks at TestContainers maintain [a fork of Docker.DotNet](https://github.com/testcontainers/Docker.DotNet) that is compatible with Docker Engine 29.

This PR provides the minor changes needed between the old package and the new Docker.DotNet.Enhanced package.

It also replaces the deprecated `System.Data.SqlClient` package with the newer `Microsoft.Data.SqlClient`.

## How was this tested?
If the test step of the pipeline builds and runs correctly this PR was a successful test.