### PR TITLE
Retirement

### DIFF
--- a/src/Web/App.razor
+++ b/src/Web/App.razor
@@ -18,7 +18,7 @@
 		<CascadingValue Value="@HeaderTitle">
 			<CascadingValue Value="@NavLinks">
 				<LayoutView Layout="@typeof(ItpMainLayout)">
-					<p>Sorry, there's nothing at this address.</p>
+					<p>This page is no longer available. Please visit the <a href="/">IT People home page</a> for support resources.</p>
 				</LayoutView>
 			</CascadingValue>
 		</CascadingValue>

--- a/src/Web/App.razor
+++ b/src/Web/App.razor
@@ -28,33 +28,4 @@
 	public string HeaderTitle = "IT People";
 	public string PrivacyNoticeUrl = "/privacy";
 	public List<AbstractHeaderItem> NavLinks = new List<AbstractHeaderItem>();
-	private List<HeaderLink> ProfileLinks = new List<HeaderLink>();
-	private AuthenticatedUser User = null;
-	private string AuthenticationDestination;
-
-	protected override async Task OnInitializedAsync()
-	{
-		User = await localStorage.GetItemAsync<AuthenticatedUser>("user");
-		var loggedInUser = User?.Username ?? "";
-		var isLoggedIn = User != null;
-		AuthenticationDestination = new Uri(Navigation.Uri).PathAndQuery;
-		var signInUrl = $"/SignIn?Destination={System.Net.WebUtility.UrlEncode(AuthenticationDestination)}";
-		
-		// Build up NavLinks.
-		NavLinks = new List<AbstractHeaderItem>();
-		if(isLoggedIn)
-		{
-			NavLinks.Add(new HeaderLink("/People", "People"));
-			NavLinks.Add(new HeaderLink("/Units", "Units"));
-			NavLinks.Add(new HeaderLink("/Search", "Search"));
-			ProfileLinks.Insert(0, new HeaderLink($"/People/{loggedInUser}", "Profile", "Manage your profile information"));
-			ProfileLinks.Add(new HeaderLink("/SignOut", "Log Out"));
-			NavLinks.Add(new HeaderProfile(loggedInUser, ProfileLinks, null, isLoggedIn));
-		}
-		else
-		{
-			NavLinks.Add(new HeaderLink(signInUrl, "Log In"));
-		}
-
-	}
 }

--- a/src/Web/Pages/BuildingPage.razor
+++ b/src/Web/Pages/BuildingPage.razor
@@ -4,7 +4,7 @@
 @using RivetBlazor.Components
 @implements IDisposable
 @inherits PageBase
-@page "/buildings/{BuildingId}"
+@* @page "/buildings/{BuildingId}" *@
 
 <PageTitle>@GetPageTitle()</PageTitle>
 <HeaderNavBar Page="Buildings" CurrentPage=@_Building.Name />

--- a/src/Web/Pages/DepartmentPage.razor
+++ b/src/Web/Pages/DepartmentPage.razor
@@ -4,7 +4,7 @@
 @using RivetBlazor.Components
 @implements IDisposable
 @inherits PageBase
-@page "/departments/{DepartmentId}"
+@* @page "/departments/{DepartmentId}" *@
 
 <PageTitle>@GetPageTitle()</PageTitle>
 <HeaderNavBar Page="Departments" CurrentPage=@_Department.Name />

--- a/src/Web/Pages/Index.razor
+++ b/src/Web/Pages/Index.razor
@@ -1,27 +1,46 @@
-﻿@using web.Shared;
-@implements IDisposable
 @page "/"
 
 <PageTitle>IT People - Indiana University</PageTitle>
 
 <div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">
-	<h1 class="rvt-ts-32 rvt-ts-41-lg-up rvt-text-bold">IT People</h1>
-	<AuthenticatedView>
-		<Authenticated>
-			<p>
-				IT People is a directory of people doing or supporting information technology (IT) work at Indiana University. You can search for <a href="/units">units</a> and people by name, or browse all units and their membership.
-			</p>
-		</Authenticated>
-		<NotAuthenticated>
-			<p>
-				IT People is a directory of people doing or supporting information technology (IT) work at Indiana University. Please log in to browse the directory.
-			</p>
-			<p>
-				<a class="rvt-button" href="/SignIn">Log In</a>
-			</p>
-		</NotAuthenticated>
-	</AuthenticatedView>
+	<h1 class="rvt-ts-32 rvt-ts-41-lg-up rvt-text-bold">IT People Has Been Retired</h1>
+	<p class="rvt-m-top-md">
+		The IT People application has been retired. Please see the resources below for support and access to tools previously managed through IT People.
+	</p>
+
+	<div class="rvt-card rvt-m-top-xl">
+		<div class="rvt-card__body">
+			<h2 class="rvt-card__title">Getting IT Support</h2>
+			<p>To get IT support, use the following resources:</p>
+			<ul class="rvt-list">
+				<li>
+					<a href="https://uits.iu.edu/get-help/">How to get help with IT</a> &mdash; Contact UITS for assistance with general IT issues and services.
+				</li>
+				<li>
+					<a href="https://uits.iu.edu/services/it-education-and-community-support/it-community-partnerships/index.html">IT Community Partnerships (ITCP)</a> &mdash; For information about your unit's local or zone support.
+				</li>
+			</ul>
+		</div>
+	</div>
+
+	<div class="rvt-card rvt-m-top-lg">
+		<div class="rvt-card__body">
+			<h2 class="rvt-card__title">Access to Previously Managed Tools</h2>
+			<p>If your team needs access to tools previously managed through IT People, please contact the appropriate team for assistance:</p>
+			<ul class="rvt-list">
+				<li>
+					<strong>Unblock</strong> &mdash; Contact <a href="https://informationsecurity.iu.edu/">UIPO</a>
+				</li>
+				<li>
+					<strong>ClearPass</strong> &mdash; Contact <a href="https://uits.iu.edu/services/wifi-and-networks/telecommunications/">IU Network Operations Center</a>
+				</li>
+				<li>
+					<strong>SuperPass or AMS</strong> &mdash; Contact <a href="https://servicenow.iu.edu/kb?id=kb_article_view&sysparm_article=KB0023158">Identity Management Systems</a>
+				</li>
+				<li>
+					<strong>CCI Tools</strong> &mdash; Contact the ADS Admin team via the <a href="https://tools.cci.iu.edu/#/feedback/form">Feedback Form</a>
+				</li>
+			</ul>
+		</div>
+	</div>
 </div>
-@code{
-	public void Dispose() {	}
-}

--- a/src/Web/Pages/People.razor
+++ b/src/Web/Pages/People.razor
@@ -10,7 +10,7 @@
 @inject IJSRuntime JSRuntime;
 @implements IDisposable
 @inherits PageBase
-@page "/People"
+@* @page "/People" *@
 
 <PageTitle>People - IT People - Indiana University</PageTitle>
 <HeaderNavBar Page="People" />

--- a/src/Web/Pages/Privacy.razor
+++ b/src/Web/Pages/Privacy.razor
@@ -1,5 +1,5 @@
 @using web.Shared
-@page "/Privacy"
+@* @page "/Privacy" *@
 
 <PageTitle>Privacy - IT People - Indiana University</PageTitle>
 <HeaderNavBar Page="Privacy" />

--- a/src/Web/Pages/Privacy.razor
+++ b/src/Web/Pages/Privacy.razor
@@ -1,5 +1,5 @@
 @using web.Shared
-@* @page "/Privacy" *@
+@page "/Privacy"
 
 <PageTitle>Privacy - IT People - Indiana University</PageTitle>
 <HeaderNavBar Page="Privacy" />

--- a/src/Web/Pages/Profile/EditInterests.razor
+++ b/src/Web/Pages/Profile/EditInterests.razor
@@ -6,7 +6,7 @@
 @implements IDisposable
 @inherits PageBase
 @inject NavigationManager Navigation
-@page "/people/{NetId}/EditInterests"
+@* @page "/people/{NetId}/EditInterests" *@
 
 <PageTitle>Edit Interests</PageTitle>
 <br/>

--- a/src/Web/Pages/Profile/EditResponsibilities.razor
+++ b/src/Web/Pages/Profile/EditResponsibilities.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 @inherits PageBase
 @inject NavigationManager Navigation
-@page "/people/{NetId}/EditResponsibilities"
+@* @page "/people/{NetId}/EditResponsibilities" *@
 
 <PageTitle>Edit Responsibilities</PageTitle>
 <br />

--- a/src/Web/Pages/Profile/PersonProfile.razor
+++ b/src/Web/Pages/Profile/PersonProfile.razor
@@ -7,7 +7,7 @@
 @inherits PageBase
 @inject IJSRuntime JSRuntime;
 @implements IDisposable
-@page "/People/{NetId}"
+@* @page "/People/{NetId}" *@
 
 <PageTitle>@GetPageTitle()</PageTitle>
 <HeaderNavBar Page="Profiles" CurrentPage=@ProfileName />

--- a/src/Web/Pages/Search.razor
+++ b/src/Web/Pages/Search.razor
@@ -6,7 +6,7 @@
 @inject IHttpClientFactory ClientFactory
 @implements IDisposable
 @inherits PageBase
-@page "/Search"
+@* @page "/Search" *@
 
 <PageTitle>Search - IT People - Indiana University</PageTitle>
 

--- a/src/Web/Pages/SignIn.razor
+++ b/src/Web/Pages/SignIn.razor
@@ -11,7 +11,7 @@
 @inject Blazored.LocalStorage.ILocalStorageService localStorage
 @implements IDisposable
 @inherits PageBase
-@page "/SignIn"
+@* @page "/SignIn" *@
 <PageTitle>Sign In - IT People - Indiana University</PageTitle>
 <div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">
 	<h1 class="rvt-ts-32 rvt-ts-41-lg-up rvt-text-bold">Sign In</h1>

--- a/src/Web/Pages/SignOut.razor
+++ b/src/Web/Pages/SignOut.razor
@@ -4,7 +4,7 @@
 @inject NavigationManager Navigation
 @implements IDisposable
 @inherits PageBase
-@page "/SignOut"
+@* @page "/SignOut" *@
 <PageTitle>Sign Out - IT People - Indiana University</PageTitle>
 <div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">
 	<h1 class="rvt-ts-32 rvt-ts-41-lg-up rvt-text-bold">Sign Out</h1>

--- a/src/Web/Pages/Units/Unit.razor
+++ b/src/Web/Pages/Units/Unit.razor
@@ -7,9 +7,9 @@
 @inject NavigationManager Navigation
 @implements IDisposable
 @inherits PageBase
-@page "/Units/create"
-@page "/Units/{unitId}"
-@page "/Units/{unitId}/edit"
+@* @page "/Units/create" *@
+@* @page "/Units/{unitId}" *@
+@* @page "/Units/{unitId}/edit" *@
 
 <PageTitle>@GetPageTitle()</PageTitle>
 <div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">

--- a/src/Web/Pages/Units/UnitAddMember.razor
+++ b/src/Web/Pages/Units/UnitAddMember.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 @inherits PageBase
 @inject NavigationManager Navigation
-@page "/Units/{unitId}/AddMember"
+@* @page "/Units/{unitId}/AddMember" *@
 
 <PageTitle>@GetPageTitle()</PageTitle>
 <div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">

--- a/src/Web/Pages/Units/UnitMemberPage.razor
+++ b/src/Web/Pages/Units/UnitMemberPage.razor
@@ -6,7 +6,7 @@
 @implements IDisposable
 @inherits PageBase
 @inject NavigationManager Navigation
-@page "/Units/{unitId}/EditMember/{username}"
+@* @page "/Units/{unitId}/EditMember/{username}" *@
 
 <PageTitle>@GetPageTitle()</PageTitle>
 <div class="rvt-container rvt-container--senior rvt-container--center rvt-p-bottom-xl rvt-p-top-lg">

--- a/src/Web/Pages/Units/Units.razor
+++ b/src/Web/Pages/Units/Units.razor
@@ -6,7 +6,7 @@
 @inject IHttpClientFactory ClientFactory
 @implements IDisposable
 @inherits PageBase
-@page "/Units"
+@* @page "/Units" *@
 
 <PageTitle>Units - IT People - Indiana University</PageTitle>
 


### PR DESCRIPTION
## ServiceNow Story Number and Description
[STRY0014876](https://servicenow.iu.edu/nav_to.do?uri=rm_story.do?sys_id=c1c0648547c9361c2fc6a55b416d4310%26sysparm_view=scrum) - Retire IT People

## Motivation and Context
This PR replaces the landing page with information about getting support and contact information for modernized tool access.  It also removes all links from the header, and disables all other pages , except `/privacy` which is used in the footer.

The IT People site is no longer a critical as it used to be, the very last things it was providing were support relationship data, and tool assignments.

After several reorgs and staff departures the support relationship data was no longer of the quality it once had been, and with the move to "zone" based support is largely no longer relevant.

Tool assignments are better handled by Grouper or Entra groups that have integrations to automatically flag departures, compliance, and position changes.

## How was this tested?
Tested locally

## Screenshots (if appropriate)
<img width="1147" height="828" alt="image" src="https://github.com/user-attachments/assets/bdb22921-a90c-4730-b933-2fb14867ac84" />
